### PR TITLE
fix: A repair round wipes the earlier notes out of an epic child's deviations comment

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -113,7 +113,9 @@ Deviations` headings and refuses two as undecidable, so a stacked marker leaves 
 reading `malformed`; and because `wire read` judges bytes on stdin and cannot see which comment is
 newer, the one-marker rule lives where the bytes are written — `fabrika build deviations <issue>`
 edits the standing marker in place and retracts any superseded one, and it is the only sanctioned
-way this marker is posted.
+way this marker is posted. Editing in place puts the whole-range completeness of the disclosure at
+that same seam: the verb compares each replacement against the standing one and refuses a section
+that drops an entry, because a reader of these bytes sees only the round that wrote them.
 
 ### `verdict-marker`
 

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -357,6 +357,22 @@ round leaves two markers, and the reader refuses two conforming headings as unde
 UNKNOWN the tail review cannot pass. Re-run the verb on every round: it edits the standing
 marker in place.
 
+**On every round after the first, the section you send is the whole range's disclosure, not the
+round's.** Editing in place means what you send *replaces* what stands, so the entries the round
+before yours disclosed — still true of the range a reviewer grades — leave with your rewrite unless
+you carry them. Read what stands first, and build this round's section out of it:
+
+```bash
+fabrika build deviations <n> --token <claim-token> --standing > round.md
+```
+
+That prints the standing `## Deviations` section, or nothing when yours is the first round. Edit
+`round.md`: keep every entry still true, add this round's, and **retire an entry by restating it
+with a `Disposition` that says what became of it** — `corrected — the revert in <sha> removes it`,
+never by deleting the bullet. Entries match on `Said`, so revise `Did`, `Why` and `Disposition`
+freely. Send the result on stdin as above; a section that drops a standing entry is exit `35`,
+naming each one.
+
 The epic-tail review reads every landed child's comment from there, so a child with nothing to
 disclose still posts the checked `None.` — an absent comment reads as "never considered it", not as
 "nothing to disclose". A child that lands its commit and posts that comment ends on `BUILT-NO-PR`,
@@ -623,6 +639,10 @@ and report that terminal with `--cause worktree-holds-branch`, the park this exa
 `recipe unpark` can clear it without a person. From
 there the loop is the ordinary one minus the publishing half: fix, `build
 check`, `build commit`, no push and no PR, then the `build-deviations` comment and `BUILT-NO-PR`.
+**That comment discloses this child's whole `base..tip` range, not the commits this round added** —
+so run `build deviations <n> --standing` before you author it, judge every entry it prints against
+the range as it now stands, and send back all of them plus your own. The verb refuses a section that
+drops one.
 `build clear` is not the door on this path — it is pull-request-keyed from its first line, and a
 child opens none — so a child at its cap escalates to the driver, whose `lane clear` records the
 grant against the lane's own log instead. That is still not yours to run: you escalate, the driver

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -12,6 +12,8 @@
 
 **Amended 2026-08-21** — `build deviations`: the epic child's disclosure had no verb, so the skill hand-rolled `wire emit` into a raw issue-comment call, which appends. A repair round left the child carrying two markers, and `wire read --format build-deviations` refuses two conforming headings as undecidable — so a repaired child stranded its epic's whole tail review. The verb owns the write seam and holds one marker per issue: the standing marker is edited in place, every superseded one is retracted, and the landed comment is read back. No new code — it allocates from the shared matrix.
 
+**Amended 2026-09-10** — `build deviations`: one marker replaced in place made a round's natural rewrite the whole standing disclosure, so a repair's entries silently retired the round before it — one child's standing text named four repair entries and dropped three still true of the range a reviewer was grading. The replacement is now compared against the standing disclosure and refused when it drops an entry, on a new code (`35`); an entry leaves only by restating it with a `Disposition` that says what became of it. `--standing` prints the standing section so a round can carry it forward without reading GitHub's edit history. The wire format, the one-marker rule, the claim gate, the leak scan and the read-back are untouched.
+
 The verbs land in `packages/fabrika-cli/` under the `build` subcommand group, registered in
 `packages/fabrika-cli/src/registry.ts` like the shipped `adr`, `report`, `triage` and `wire`
 groups. The [CLI interface convention](../../docs/cli-interface-convention.md) governs every verb;
@@ -85,7 +87,7 @@ second answer to a gated question can contradict the gate (interface convention 
 | `build pr` | open the PR from a stdin body, refusing the known defect shapes, with read-back | mechanical guards over an authored body; *authoring* stays in the skill |
 | `build pr-body` | replace an open PR's body from a stdin body, under `build pr`'s guards, with read-back | the same mechanical guards as `build pr`, over a `PATCH` that moves no ref; *authoring* stays in the skill |
 | `build note` | post a progress/handoff comment, head-stamped, leak-guarded, with read-back | as `report note`, plus the head stamp |
-| `build deviations` | post an epic child's `## Deviations` disclosure as the ONE `build-deviations` marker on its issue, edited in place on every later round | a claim-gated upsert with a read-back, over a section validated by the wire format; *authoring* the disclosure stays in the skill |
+| `build deviations` | post an epic child's `## Deviations` disclosure as the ONE `build-deviations` marker on its issue, edited in place on every later round and carrying every standing entry; `--standing` reads what stands | a claim-gated upsert with a read-back, over a section validated by the wire format and compared against the standing disclosure; *authoring* the disclosure stays in the skill |
 | `build verdicts` | the paginated, per-gate verdict fold: current-head on a PR, range-bound on an epic child | fetch-all + fold via the wire module; *acting on rows* stays in the skill |
 | `build clear` | record the founder's clearance of one extra repair round on a PR | a conjunctive ACL/authorization protocol with read-back; *whether to grant* is the founder's, never the verb's |
 
@@ -350,6 +352,7 @@ range, exactly as `triage/codes.ts` itself states for `adr`.
 | `32` | proven: not admitted on the criteria axis — the issue body carries no readable `### Acceptance criteria` block, absent or malformed, so there is no contract to build against |
 | `33` | proven: a working tree of this clone holds the lane branch, and the board licenses no release of it |
 | `34` | proven: no authorized claim marker attests a single survivor among a child's lane branches, so none is superseded |
+| `35` | proven: a replacement disclosure drops an entry the standing marker discloses — a well-formed section that discloses less of the range than the round before it, which is why it is not `4` |
 | `127` | the verb never ran at all (unresolved binary — the shell's code, not this process's) |
 
 **`7` versus `11` is the split the whole group rests on** (the `wire` group's `ABSENT` vs
@@ -2653,6 +2656,8 @@ fabrika build deviations 6566 --token <token> [--repo <owner/name>] <<'EOF'
 
 None.
 EOF
+
+fabrika build deviations 6566 --token <token> --standing   # read what a round carries forward
 ```
 
 **Inputs**
@@ -2662,12 +2667,28 @@ EOF
 | `<issue>` | positional integer | yes | — | the epic child the disclosure is for, and the issue the marker sits on. A pull request is `10`: a PR discloses in its body, which is `build pr` / `build pr-body` |
 | `--repo` | string | no | the `origin` remote's `owner/name` | the repository written to |
 | `--token` | string | yes | — | the token `build claim` handed this lane — which lane is asking. Not a claim token, or one carrying another session id, is `1` |
-| stdin | text | yes | — | the `## Deviations` section, read through the `deviations` wire format before anything is written |
+| `--standing` | boolean | no | `false` | read instead of write: print the standing disclosure, take nothing on stdin, and change nothing |
+| stdin | text | yes, without `--standing` | — | the `## Deviations` section, read through the `deviations` wire format before anything is written |
 
 **Output** — machine.
 `{"answer": "posted", "issue": 6566, "commentId": 900, "upsert": "created", "retracted": 0, "url": "https://<host>/<owner>/<repo>/issues/6566#issuecomment-900"}`.
 `upsert` is `"created"` when the child carried no standing marker and `"edited"` when one was
 PATCHed in place; `retracted` counts the superseded markers deleted behind it.
+
+**Output under `--standing`** — the standing marker's `## Deviations` section on stdout, as the
+`deviations` format composes it, with the comment id on stderr. A child carrying no marker yet
+prints nothing at exit `0`, and stderr says so — a proven "nothing to carry forward", not a failure.
+
+**The marker discloses the whole reviewed range, not the round that wrote it.**
+Replacement in place means a repair round's natural rewrite — the entries that round produced —
+retires everything the round before it disclosed. On one child that left the standing text naming four
+repair entries with three still true of the range, reachable only through GitHub's comment edit
+history, which no gate reads. So the section on stdin is compared against the standing disclosure
+before anything is written, and one that drops an entry is refused on `35` naming each: an entry
+leaves the section only by being restated with a `Disposition` that says what became of it —
+reverted, corrected, or still standing. Entries match on `Said`, so a later round revises `Did`,
+`Why` and `Disposition` freely. `--standing` is the read that feeds this: a round takes the standing
+section, edits it, and sends the result.
 
 **One marker per issue is this verb's invariant.**
 An epic child opens no PR, so its disclosure is a `build-deviations` marker comment; the tail review
@@ -2682,7 +2703,9 @@ a child a pre-fix lane already stacked.
 Guards, in order: stdin non-empty (`3`), bare-`@` body (`6`), the section readable through the
 `deviations` format (`4`), target is an open issue and not a PR (`7`/`10`), caller token parses
 (`1`), claim held (`15`/`11`), leak predicates over the composed comment (`5`), the authenticated
-user and the comment list both readable (`11`), write (`8`), read-back (`9`), retraction (`8`).
+user and the comment list both readable (`11`), every standing entry carried (`35`), write (`8`),
+read-back (`9`), retraction (`8`). Under `--standing` the first three do not run — there is no
+section — and the run ends where the comment list is read.
 
 The marker line is composed from the positional and never taken from stdin, so a disclosure cannot
 name an issue other than the one it sits on. Read-back is a re-fetch of the landed comment asserted
@@ -2704,6 +2727,7 @@ comment reads back, so a write that then fails can never destroy the standing di
 | `10` | the number is a pull request, which discloses in its body |
 | `11` | a precondition read failed — the issue, the authenticated user, or the comment list |
 | `15` | proven: this lane does not hold the claim on the issue |
+| `35` | proven: the replacement drops an entry the standing marker discloses |
 
 **Errors**
 
@@ -2723,6 +2747,7 @@ comment reads back, so a write that then fails can never destroy the standing di
 | `build deviations: cannot read #<n>'s comments: <reason> — nothing was written; a partial list would stack a second marker.` | 11 | refusal |
 | `build deviations: cannot read the authenticated user: <reason> — nothing was written.` | 11 | refusal |
 | `build deviations: #<n> is held by <winning token>, not by <caller token>.` | 15 | refusal |
+| `build deviations: the replacement drops <k> entry/entries the standing marker discloses (<each entry's Said>) — the marker discloses the whole reviewed range, not this round's commits, so an entry leaves only by restating it with a **Disposition:** that says what became of it. Read the standing text with \`fabrika build deviations <n> --standing --token <token>\`, carry each entry into the section, and re-run.` | 35 | refusal |
 
 **Scope** — one issue's marker, written by one claim-holding lane. It runs the posting guards only,
 never the tree assertions: a child's disclosure is composed from the branch's work but the comment
@@ -2742,10 +2767,38 @@ EOF
 {"answer":"posted","issue":6566,"commentId":900,"upsert":"edited","retracted":1,"url":"https://<host>/<owner>/<repo>/issues/6566#issuecomment-900"}
 ```
 
+A repair round reads what stands, then sends it back with its own entries and the retirement of one
+the repair corrected:
+
+```
+$ fabrika build deviations 6566 --token <token> --standing
+## Deviations
+
+- **Scope narrowing** — **Said:** the child names the ledger row and its header. **Did:** wrote the row only. **Why:** the header is another child's file. **Disposition:** stated here.
+
+$ fabrika build deviations 6566 --token <token> <<'EOF'
+## Deviations
+
+- **Scope narrowing** — **Said:** the child names the ledger row and its header. **Did:** wrote the
+  row only. **Why:** the header is another child's file. **Disposition:** corrected — round 2 wrote
+  the header, so nothing is narrowed.
+- **Pre-existing test or fixture changed** — **Said:** leave the round-1 fixtures alone. **Did:**
+  re-recorded the ledger fixture. **Why:** the repair changes the rows it asserts.
+  **Disposition:** stated here.
+EOF
+{"answer":"posted","issue":6566,"commentId":900,"upsert":"edited","retracted":0,"url":"https://<host>/<owner>/<repo>/issues/6566#issuecomment-900"}
+```
+
+Sending only the second entry is exit `35`, naming the first — a round cannot reset the disclosure
+to its own commits.
+
 **Grounding**
 
 - A repair round's second marker made the disclosure unreadable through `wire read`, and stranded a
   whole epic's tail review on two of its children.
+- The fix for that stacking made the standing marker the round's own text, and one child's round 2
+  then dropped three entries still true of the range — a reviewer who had not read round 1 would
+  have graded the range against a narrower disclosure than the one it owed.
 - An epic child opens no PR, which is why the disclosure surface is a comment at all.
 - The skill's hand-rolled issue-comment call is the glue a verb is supposed to own: a script may
   relay a verb's answer, never derive the decision itself.

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -207,3 +207,14 @@ export const WORKTREE_HELD = 33;
  * candidate's lane nonce there is nothing to rename.
  */
 export const SURVIVOR_UNATTESTED = 34;
+/**
+ * Proven: the replacement disclosure drops a standing entry the marker still owes.
+ *
+ * A *proven* refusal about two artifacts both read in full — the standing marker's disclosure and
+ * the section on stdin — so it never borrows {@link PRECONDITION_UNKNOWN}. Its own seat rather than
+ * {@link BAD_SECTIONS}'s: `4` says the bytes on stdin are not a section, and this says they are a
+ * perfectly well-formed section that discloses less than the round before it. The remedies share
+ * nothing — `4` is a rewrite of the grammar, this is carrying an entry forward — and a `4` here
+ * would send an author to re-read a shape that was never wrong.
+ */
+export const DISCLOSURE_INCOMPLETE = 35;

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -639,13 +639,19 @@ const deviations = leafCommand(
 			Argument.withDescription("the epic child the disclosure is for, and sits on"),
 		),
 		token: tokenFlag,
+		standing: Flag.boolean("standing").pipe(
+			Flag.withDescription(
+				"print the standing disclosure and write nothing — the entries this round carries forward (default: false)",
+			),
+		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({issue, token, repo}) {
+	Effect.fn(function* ({issue, token, standing, repo}) {
 		yield* emit(
 			yield* runDeviations({
 				issue,
 				token,
+				standing,
 				repo: Option.getOrNull(repo),
 				env: process.env,
 				stdin: Effect.sync(readStdin),
@@ -655,7 +661,7 @@ const deviations = leafCommand(
 ).pipe(
 	Command.withShortDescription("Post an epic child's deviation disclosure as its one marker."),
 	Command.withDescription(
-		'Post the "## Deviations" section on STDIN as the epic child\'s build-deviations marker comment — the disclosure surface a child has instead of a PR body. ONE marker per issue: the standing marker is edited in place and every superseded one of this account\'s is retracted, so `fabrika wire read --format build-deviations` never meets two conforming headings. The marker line is composed from the positional, so a disclosure cannot name an issue other than the one it sits on. The section is validated through the wire format before anything is written, and the landed comment is read back from live issue state. Prints {"answer":"posted","issue":n,"commentId":n,"upsert":"created"|"edited","retracted":n,"url":"…"}. Exits 1 (--token is not a claim token of this session), 3 (stdin held nothing), 4 (the "## Deviations" section is missing or malformed), 5 (machine-local path), 6 (bare @ reference), 7 (the issue is proven absent or closed), 8 (the write failed, or a superseded marker could not be retracted — UNKNOWN), 9 (posted but does not read back), 10 (the number is a pull request, which discloses in its body), 11 (a precondition read failed), 15 (this LANE does not hold the claim). Example: fabrika build deviations 6566 --token build:s-9f2e:c1a4d6f8-… < deviations.md',
+		'Post the "## Deviations" section on STDIN as the epic child\'s build-deviations marker comment — the disclosure surface a child has instead of a PR body. ONE marker per issue: the standing marker is edited in place and every superseded one of this account\'s is retracted, so `fabrika wire read --format build-deviations` never meets two conforming headings. That marker discloses the WHOLE reviewed range, so the replacement is compared against the standing disclosure and refused when it drops an entry — an entry leaves only by restating it with a **Disposition:** saying what became of it. With --standing the verb reads instead: stdin is not read, nothing is written, and the standing section is printed for the round to carry forward (empty when the child carries no marker yet). The marker line is composed from the positional, so a disclosure cannot name an issue other than the one it sits on. The section is validated through the wire format before anything is written, and the landed comment is read back from live issue state. Prints {"answer":"posted","issue":n,"commentId":n,"upsert":"created"|"edited","retracted":n,"url":"…"}. Exits 1 (--token is not a claim token of this session), 3 (stdin held nothing), 4 (the "## Deviations" section is missing or malformed), 5 (machine-local path), 6 (bare @ reference), 7 (the issue is proven absent or closed), 8 (the write failed, or a superseded marker could not be retracted — UNKNOWN), 9 (posted but does not read back), 10 (the number is a pull request, which discloses in its body), 11 (a precondition read failed), 15 (this LANE does not hold the claim), 35 (the replacement drops a standing entry). Example: fabrika build deviations 6566 --token build:s-9f2e:c1a4d6f8-… < deviations.md',
 	),
 );
 

--- a/packages/fabrika-cli/src/build/deviations-verb.ts
+++ b/packages/fabrika-cli/src/build/deviations-verb.ts
@@ -16,6 +16,13 @@
  * would keep the reader at `malformed` for exactly the reason the fix exists. A retraction that
  * fails is UNKNOWN and never a success: two markers still read as no disclosure at all.
  *
+ * **The marker discloses the whole reviewed range, not the round that last wrote it.** One marker
+ * replaced in place means a repair round's natural rewrite — the entries that round produced — silently
+ * retires the entries the round before it disclosed, which is how a child's standing text came to
+ * describe a narrower range than the one a reviewer grades. So the replacement is compared against
+ * the standing disclosure before it is written, and a section that drops an entry is refused: an
+ * entry leaves only by restating it under a `Disposition` that says what became of it.
+ *
  * The marker line is composed here from the positional, never taken from stdin, so a disclosure
  * cannot name an issue other than the one it sits on.
  */
@@ -40,6 +47,7 @@ import {leakRefusal, readAuthored} from "./authored.ts";
 import {requireCallerToken, requireClaim, requireSession} from "./claim.ts";
 import {
 	BAD_SECTIONS,
+	DISCLOSURE_INCOMPLETE,
 	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
@@ -62,27 +70,79 @@ export interface DeviationsOptions {
 	readonly issue: number;
 	/** The token `build claim` handed this lane — the identity it posts under. */
 	readonly token: string;
+	/** Read the standing disclosure and write nothing — what a round carries forward. */
+	readonly standing: boolean;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
 	readonly stdin: Effect.Effect<StdinRead>;
 }
 
+/** A standing marker of this account's, with the disclosure it already carries. */
+interface StandingMarker {
+	readonly comment: CommentRecord;
+	readonly disclosure: deviations.DeviationsDisclosure;
+}
+
 /**
- * This account's standing markers for `issue`, oldest first.
+ * This account's standing markers for `issue`, oldest first, each with its disclosure read out.
  *
  * Read through the format rather than by prefix match, so a comment that merely quotes the marker
  * line is not mistaken for one, and a marker disclosing for another issue is never edited from here.
+ * The disclosure rides along because the carry-forward gate needs it and a second read of the same
+ * bytes could answer differently from the one that selected the comment.
  */
 const standingMarkers = (
 	comments: ReadonlyArray<CommentRecord>,
 	me: string,
 	issue: number,
-): ReadonlyArray<CommentRecord> =>
-	comments.filter((comment) => {
-		if (comment.author !== me) return false;
+): ReadonlyArray<StandingMarker> =>
+	comments.flatMap((comment) => {
+		if (comment.author !== me) return [];
 		const read = buildDeviations.read(comment.body);
-		return read._tag === "Found" && read.value.issue === issue;
+		return read._tag === "Found" && read.value.issue === issue
+			? [{comment, disclosure: read.value.disclosure}]
+			: [];
 	});
+
+type Ask =
+	| {readonly _tag: "Read"}
+	| {
+			readonly _tag: "Post";
+			readonly section: deviations.DeviationsDisclosure;
+			readonly composed: string;
+	  }
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+/** The disclosure on stdin, composed for `issue` — or the refusal its bytes earned. */
+const askedDisclosure = (issue: number, stdin: StdinRead): Ask => {
+	const authored = readAuthored(SURFACE, stdin);
+	if (authored._tag === "Refused") return {_tag: "Refused", outcome: authored.outcome};
+
+	const section = deviations.read(authored.text);
+	if (section._tag === "Absent") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(
+				BAD_SECTIONS,
+				`${VERB}: the disclosure carries no "${"#".repeat(deviations.HEADING_LEVEL)} ${deviations.HEADING_TEXT}" heading — ${section.reason}.`,
+			),
+		};
+	}
+	if (section._tag === "Malformed") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(
+				BAD_SECTIONS,
+				`${VERB}: the disclosure is malformed — ${section.reason} (${section.evidence}).`,
+			),
+		};
+	}
+	return {
+		_tag: "Post",
+		section: section.value,
+		composed: buildDeviations.emit({issue, disclosure: section.value}),
+	};
+};
 
 /**
  * Why the re-fetched comment does not show what was posted, or `null` when it does.
@@ -120,22 +180,10 @@ export const runDeviations = (
 	Effect.gen(function* () {
 		const {issue} = options;
 
-		const authored = readAuthored(SURFACE, yield* options.stdin);
-		if (authored._tag === "Refused") return authored.outcome;
-
-		const section = deviations.read(authored.text);
-		if (section._tag === "Absent") {
-			return refuse(
-				BAD_SECTIONS,
-				`${VERB}: the disclosure carries no "${"#".repeat(deviations.HEADING_LEVEL)} ${deviations.HEADING_TEXT}" heading — ${section.reason}.`,
-			);
-		}
-		if (section._tag === "Malformed") {
-			return refuse(
-				BAD_SECTIONS,
-				`${VERB}: the disclosure is malformed — ${section.reason} (${section.evidence}).`,
-			);
-		}
+		const ask: Ask = options.standing
+			? {_tag: "Read"}
+			: askedDisclosure(issue, yield* options.stdin);
+		if (ask._tag === "Refused") return ask.outcome;
 
 		const sessionRead = requireSession(VERB, options.env);
 		if (sessionRead._tag === "Refused") return sessionRead.outcome;
@@ -170,9 +218,10 @@ export const runDeviations = (
 		const held = yield* requireClaim(VERB, repo, issue, asking.caller);
 		if (held._tag === "Refused") return held.outcome;
 
-		const composed = buildDeviations.emit({issue, disclosure: section.value});
-		const leaked = leakRefusal(VERB, composed);
-		if (leaked !== null) return leaked;
+		if (ask._tag === "Post") {
+			const leaked = leakRefusal(VERB, ask.composed);
+			if (leaked !== null) return leaked;
+		}
 
 		const me = yield* viewerLogin;
 		if (me._tag === "Failure") {
@@ -195,16 +244,38 @@ export const runDeviations = (
 		// the first match would revise a superseded disclosure and leave the live one untouched.
 		const current = standing.at(-1);
 
+		if (ask._tag === "Read") {
+			return answer(
+				current === undefined ? "" : deviations.emit(current.disclosure),
+				current === undefined
+					? [
+							...held.notes,
+							`${VERB}: #${issue} carries no standing marker — this round's disclosure is the first.`,
+						]
+					: [...held.notes, `${VERB}: standing marker: comment ${current.comment.id}.`],
+			);
+		}
+
+		const dropped =
+			current === undefined ? [] : deviations.droppedEntries(current.disclosure, ask.section);
+		if (dropped.length > 0) {
+			return refuse(
+				DISCLOSURE_INCOMPLETE,
+				`${VERB}: the replacement drops ${dropped.length} entry/entries the standing marker discloses (${dropped.map((entry) => `"${entry.said}"`).join("; ")}) — the marker discloses the whole reviewed range, not this round's commits, so an entry leaves only by restating it with a **${deviations.fieldLabel("disposition")}:** that says what became of it. Read the standing text with \`fabrika build deviations ${issue} --standing --token <token>\`, carry each entry into the section, and re-run.`,
+				held.notes,
+			);
+		}
+
 		let landed: {readonly id: number; readonly url: string} | null = null;
 		let failure: string | null = null;
 		if (current === undefined) {
-			const created = yield* createComment(repo, issue, composed);
+			const created = yield* createComment(repo, issue, ask.composed);
 			if (created._tag === "Failure") failure = created.reason;
 			else landed = {id: created.value.id, url: created.value.url};
 		} else {
-			const edited = yield* patchComment(repo, current.id, composed);
+			const edited = yield* patchComment(repo, current.comment.id, ask.composed);
 			if (edited._tag === "Failure") failure = edited.reason;
-			else landed = {id: current.id, url: edited.value};
+			else landed = {id: current.comment.id, url: edited.value};
 		}
 		if (landed === null) {
 			return refuse(
@@ -218,7 +289,7 @@ export const runDeviations = (
 		// The write call's own echo is not evidence: re-fetch, and assert both halves — the
 		// bytes that were sent, and that the format still reads them as this issue's disclosure.
 		const back = yield* getComment(repo, landed.id);
-		const mismatch = readbackMismatch(back, composed, issue);
+		const mismatch = readbackMismatch(back, ask.composed, issue);
 		if (mismatch !== null) {
 			return refuse(
 				READBACK_MISMATCH,
@@ -229,11 +300,11 @@ export const runDeviations = (
 
 		// Retract every older marker only once the live one is proven — a retraction taken first would
 		// destroy the standing disclosure on a write that then failed.
-		const stale = standing.filter((comment) => comment.id !== landed.id);
+		const stale = standing.filter((marker) => marker.comment.id !== landed.id);
 		const leftover: number[] = [];
-		for (const comment of stale) {
-			const removed = yield* deleteComment(repo, comment.id);
-			if (removed._tag === "Failure") leftover.push(comment.id);
+		for (const marker of stale) {
+			const removed = yield* deleteComment(repo, marker.comment.id);
+			if (removed._tag === "Failure") leftover.push(marker.comment.id);
 		}
 		if (leftover.length > 0) {
 			return refuse(

--- a/packages/fabrika-cli/src/build/deviations-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/deviations-verb.unit.test.ts
@@ -3,9 +3,11 @@ import {describe, expect, it} from "vitest";
 import {fakeSeams, once, type Scripted} from "../fakes.test-support.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import * as buildDeviations from "../wire/build-deviations.ts";
+import * as deviations from "../wire/deviations.ts";
 import {
 	BAD_SECTIONS,
 	CLAIM_NOT_MINE,
+	DISCLOSURE_INCOMPLETE,
 	EMPTY_STDIN,
 	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
@@ -49,6 +51,60 @@ const FULL = [
 	"",
 ].join("\n");
 
+/**
+ * The two rounds of the epic child the carry-forward gate was written from.
+ *
+ * Round 1 disclosed the three entries below; round 2's repair rewrote the section with its own and
+ * left all three behind, so a cold later reviewer read a narrower range than the one being graded
+ * and the dropped entries survived only in GitHub's comment edit history.
+ */
+const SERVER_BINDING = [
+	"- **Out-of-scope change** — **Said:** the child names the history mapper. **Did:** also narrowed",
+	"  `QueryOptionsInput.server` to `ServerBinding`. **Why:** the mapper's caller does not type-check",
+	"  without it. **Disposition:** stated here.",
+].join("\n");
+
+const NEWLINE_JOIN = [
+	"- **Known defect left unfixed** — **Said:** map every content block to a row. **Did:** the",
+	"  `content_block_start` arm joins its text on a newline. **Why:** the stream sends no separator.",
+	"  **Disposition:** stated here.",
+].join("\n");
+
+const UNSETTLED_STREAM = [
+	"- **Known defect left unfixed** — **Said:** every row settles. **Did:** an unsettled stream leaves",
+	"  its last row partial until the next `message_start`. **Why:** nothing else closes the row.",
+	"  **Disposition:** filed as a follow-up.",
+].join("\n");
+
+/** The same deviation the repair corrected — same **Said**, a disposition that says so. */
+const UNSETTLED_STREAM_RETIRED = UNSETTLED_STREAM.replace(
+	"**Disposition:** filed as a follow-up.",
+	"**Disposition:** corrected — the row now settles on stream end.",
+);
+
+/** The repair round's own entry — what an author writes when the section is rewritten from scratch. */
+const ROUND_TWO_OWN = [
+	"- **Pre-existing test or fixture changed** — **Said:** leave the round-1 fixtures alone. **Did:**",
+	"  re-recorded the mapper fixture. **Why:** the repair changes the rows it asserts.",
+	"  **Disposition:** stated here.",
+].join("\n");
+
+const sectionOf = (...entries: ReadonlyArray<string>): string =>
+	["## Deviations", "", ...entries, ""].join("\n");
+
+const ROUND_ONE = sectionOf(SERVER_BINDING, NEWLINE_JOIN, UNSETTLED_STREAM);
+
+/** Round 2 as it must be authored: the standing entries carried, the corrected one disposed of. */
+const ROUND_TWO_COMPLETE = sectionOf(
+	SERVER_BINDING,
+	NEWLINE_JOIN,
+	UNSETTLED_STREAM_RETIRED,
+	ROUND_TWO_OWN,
+);
+
+/** Round 2 as the bug wrote it: the round's own commits, and nothing of the range before them. */
+const ROUND_TWO_RESET = sectionOf(ROUND_TWO_OWN);
+
 /** What the format composes for this issue — the bytes the verb must land, byte for byte. */
 const composed = (section: string): string => {
 	const read = buildDeviations.read(`${buildDeviations.KEY_PREFIX} #${ISSUE}\n\n${section}`);
@@ -56,9 +112,22 @@ const composed = (section: string): string => {
 	return buildDeviations.emit(read.value);
 };
 
+/** The disclosure a marker's bytes carry — read out of the fixture, never asserted by hand. */
+const disclosureOf = (marker: string): deviations.DeviationsDisclosure => {
+	const read = buildDeviations.read(marker);
+	if (read._tag !== "Found") throw new Error(`fixture marker is not readable: ${read._tag}`);
+	return read.value.disclosure;
+};
+
+/** stdin `--standing` must never reach: the read mode asks for no section and writes nothing. */
+const UNREAD: Effect.Effect<StdinRead> = Effect.sync(() => {
+	throw new Error("stdin was read under --standing");
+});
+
 const options = {
 	issue: ISSUE,
 	token: LANE_TOKEN,
+	standing: false,
 	repo: null,
 	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e", ...GH_TOKEN_ENV} as Record<
 		string,
@@ -159,6 +228,102 @@ describe("runDeviations", () => {
 		expect(second.requests.some((line) => POST.test(line))).toBe(false);
 		// The second emit's bytes are what the verb read back — the criterion's other half.
 		expect(writtenBody(second, PATCH)).toBe(composed(FULL));
+	});
+
+	it("lands a repair round that carries the standing entries beside its own", async () => {
+		const seams = seamsFor([
+			...board({id: 900, body: composed(ROUND_ONE)}),
+			[PATCH, served({id: 900, html_url: "https://example.test/o/r/issues/6566#c900"})],
+			[getComment(900), served({body: composed(ROUND_TWO_COMPLETE)})],
+			[POST, served({message: "a second comment must never be created"}, 500)],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runDeviations({
+					...options,
+					stdin: Effect.succeed({_tag: "Text", text: ROUND_TWO_COMPLETE}),
+				}),
+				seams.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({commentId: 900, upsert: "edited"});
+
+		// One marker, four entries: the three round 1 disclosed and the one round 2 added — so a cold
+		// later reviewer reads the whole range off the standing text, never off the edit history.
+		const landed = writtenBody(seams, PATCH);
+		const read = buildDeviations.read(landed);
+		expect(read._tag).toBe("Found");
+		expect(landed.split("\n").filter((line) => line === "## Deviations")).toHaveLength(1);
+		const disclosure = read._tag === "Found" ? read.value.disclosure : null;
+		expect(disclosure?._tag === "Entries" ? disclosure.entries.length : 0).toBe(4);
+		for (const said of ["QueryOptionsInput", "content block", "every row settles"]) {
+			expect(landed).toContain(said);
+		}
+	});
+
+	/**
+	 * The bug itself: round 2's natural rewrite discloses its own commits, and the standing
+	 * entries — still true of the range the next reviewer grades — go with it.
+	 */
+	it("refuses a replacement that drops a standing entry, naming each one, before any write", async () => {
+		const seams = seamsFor(board({id: 900, body: composed(ROUND_ONE)}));
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runDeviations({...options, stdin: Effect.succeed({_tag: "Text", text: ROUND_TWO_RESET})}),
+				seams.layer,
+			),
+		);
+		expect(out.code).toBe(DISCLOSURE_INCOMPLETE);
+		const said = out.stderr.join("\n");
+		expect(said).toContain("the child names the history mapper");
+		expect(said).toContain("map every content block to a row");
+		expect(said).toContain("every row settles");
+		expect(seams.requests.some((line) => POST.test(line) || PATCH.test(line))).toBe(false);
+	});
+
+	it('refuses a replacement that resets the disclosure to "None."', async () => {
+		const out = await run(board({id: 900, body: composed(ROUND_ONE)}), {
+			stdin: Effect.succeed({_tag: "Text", text: NONE}),
+		});
+		expect(out.code).toBe(DISCLOSURE_INCOMPLETE);
+	});
+
+	it("takes a re-stated entry as carried however its later fields read", async () => {
+		const seams = seamsFor([
+			...board({id: 900, body: composed(sectionOf(UNSETTLED_STREAM))}),
+			[PATCH, served({id: 900, html_url: "https://example.test/o/r/issues/6566#c900"})],
+			[getComment(900), served({body: composed(sectionOf(UNSETTLED_STREAM_RETIRED))})],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runDeviations({
+					...options,
+					stdin: Effect.succeed({_tag: "Text", text: sectionOf(UNSETTLED_STREAM_RETIRED)}),
+				}),
+				seams.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(writtenBody(seams, PATCH)).toContain("corrected — the row now settles");
+	});
+
+	it("prints the standing disclosure under --standing, and writes nothing", async () => {
+		const seams = seamsFor(board({id: 900, body: composed(ROUND_ONE)}));
+		const out = await Effect.runPromise(
+			Effect.provide(runDeviations({...options, standing: true, stdin: UNREAD}), seams.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(deviations.emit(disclosureOf(composed(ROUND_ONE))));
+		expect(out.stderr.join("\n")).toContain("comment 900");
+		expect(seams.requests.some((line) => POST.test(line) || PATCH.test(line))).toBe(false);
+	});
+
+	it("prints nothing under --standing when the child carries no marker yet", async () => {
+		const out = await run(board(), {standing: true, stdin: UNREAD});
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("no standing marker");
 	});
 
 	it("retracts a stacked marker a pre-fix lane left, so one comment survives", async () => {

--- a/packages/fabrika-cli/src/wire/deviations.ts
+++ b/packages/fabrika-cli/src/wire/deviations.ts
@@ -328,6 +328,29 @@ export const emit = (disclosure: DeviationsDisclosure): string => {
 	return `${heading}\n\n${body}\n`;
 };
 
+/**
+ * The standing entries a replacement disclosure drops — empty when it carries all of them.
+ *
+ * A round rewrites the whole section, so what an author naturally writes is that round's own
+ * entries, and the standing ones — still true of the range the next reviewer grades — go with the
+ * rewrite. An entry is keyed by its **Said**: what the spec asked is what makes it the same
+ * deviation across rounds, where `Did`, `Why` and `Disposition` are the fields a later round
+ * revises. Retiring an entry is therefore restating it with a `Disposition` that says the change was
+ * reverted or corrected, never deleting the bullet.
+ */
+export const droppedEntries = (
+	standing: DeviationsDisclosure,
+	replacement: DeviationsDisclosure,
+): ReadonlyArray<DeviationEntry> => {
+	if (standing._tag === "NoneDeclared") return [];
+	const carried = new Set(
+		replacement._tag === "NoneDeclared"
+			? []
+			: replacement.entries.map((entry) => normalize(entry.said)),
+	);
+	return standing.entries.filter((entry) => !carried.has(normalize(entry.said)));
+};
+
 export type DeviationsFields =
 	| {readonly _tag: "Fields"; readonly disclosure: DeviationsDisclosure}
 	| {readonly _tag: "Unusable"; readonly reason: string};

--- a/packages/fabrika-cli/src/wire/deviations.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/deviations.unit.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest";
-import {emitFromFields, parseFields, read} from "./deviations.ts";
+import {droppedEntries, emitFromFields, parseFields, read} from "./deviations.ts";
 
 const ENTRY =
 	"- **Scope narrowing** — **Said:** four gates. **Did:** three plus a bounce. **Why:** the fourth emits a trivial verdict. **Disposition:** stated here.";
@@ -69,5 +69,49 @@ describe("parseFields", () => {
 	it("composes bytes its own reader accepts", () => {
 		const composed = emitFromFields("-\ta.\tb.\tc.\td.\n");
 		expect(composed._tag === "Composed" && read(composed.bytes)._tag).toBe("Found");
+	});
+});
+
+describe("droppedEntries", () => {
+	/** A section's bytes as a disclosure — the fixtures read through the format that owns them. */
+	const disclose = (body: string) => {
+		const result = read(body);
+		if (result._tag !== "Found") throw new Error(`fixture is not readable: ${result._tag}`);
+		return result.value;
+	};
+
+	const OTHER =
+		"- **Out-of-scope change** — **Said:** the ledger row only. **Did:** the header too. **Why:** one helper writes both. **Disposition:** stated here.";
+
+	it("names a standing entry the replacement leaves out", () => {
+		const dropped = droppedEntries(
+			disclose(`## Deviations\n\n${ENTRY}\n${OTHER}\n`),
+			disclose(`## Deviations\n\n${OTHER}\n`),
+		);
+		expect(dropped.map((entry) => entry.said)).toEqual(["four gates."]);
+	});
+
+	it("takes an entry as carried when only its later fields changed", () => {
+		const revised = ENTRY.replace("**Disposition:** stated here.", "**Disposition:** reverted.");
+		expect(
+			droppedEntries(
+				disclose(`## Deviations\n\n${ENTRY}\n`),
+				disclose(`## Deviations\n\n${revised}\n`),
+			),
+		).toEqual([]);
+	});
+
+	it("reads a replacement of `None.` over standing entries as dropping all of them", () => {
+		const dropped = droppedEntries(
+			disclose(`## Deviations\n\n${ENTRY}\n${OTHER}\n`),
+			disclose("## Deviations\n\nNone.\n"),
+		);
+		expect(dropped).toHaveLength(2);
+	});
+
+	it("owes nothing when the standing disclosure declared none", () => {
+		expect(
+			droppedEntries(disclose("## Deviations\n\nNone.\n"), disclose(`## Deviations\n\n${ENTRY}\n`)),
+		).toEqual([]);
 	});
 });


### PR DESCRIPTION
`fabrika build deviations` posts an epic child's disclosure as one marker comment, replaced in place on every round. That replacement is total: a repair round writes the entries it produced, and the entries the round before it disclosed — still true of the range a reviewer grades — leave with the rewrite. On #8172 that left the standing text naming four repair entries with three round-1 entries dropped, reachable only through GitHub's comment edit history, which no gate reads.

The verb now compares each replacement against the standing disclosure and refuses one that drops an entry, on a new exit code `35` that names every dropped entry's **Said**. An entry leaves the section only by being restated with a `Disposition` that says what became of it — reverted, corrected, or still standing. Entries match on **Said**, so a later round revises **Did**, **Why** and **Disposition** freely; the comparison lives in `wire/deviations.ts` beside the grammar it reads.

`--standing` is the read half: it prints the standing `## Deviations` section, takes nothing on stdin and writes nothing, so a round edits what stands instead of authoring blind. A child with no marker yet prints nothing at exit 0.

**How a cold later-round reviewer gets the whole disclosure.** They read the one standing marker, exactly as before — no second comment, no archival envelope, no stacked heading. What changed is that the marker's text is now proven complete at the write seam: the only way an entry stops appearing in it is a round that never ran. The regression fixture models #8172's two rounds — the `ServerBinding` narrowing, the `content_block_start` newline join and the unsettled-stream row — and asserts the landed round-2 bytes hold all three beside the repair's own, read back as exactly one valid `build-deviations` marker with four entries.

The claim gate, the leak refusals, the one-marker retraction and the two-assertion read-back are untouched, and their tests pass unchanged.

## Deviations

- **Out-of-scope change** — **Said:** the issue names the epic-child repair path in the build skill and its command contract. **Did:** also added one sentence to `claude-plugins/fabrika/docs/wire-formats.md`. **Why:** that page's `build-deviations` section already states the one-marker rule as a property of this write seam, so a reader would otherwise learn the replacement semantics without its completeness rule. **Disposition:** stated here.
- **Scope narrowing** — **Said:** the fixture is "based on #8172". **Did:** the fixture models that child's three round-1 entries and a round-2 repair entry, but names no issue number in the shipped corpus. **Why:** `portability-guard` reds a repo-specific issue reference under `claude-plugins/**` and `packages/fabrika-cli/**`, and it reds on a count, so a new one fails the guard even under a listed row. **Disposition:** stated here; the incident is cited in this body instead.

Fixes #8321
