### PR TITLE
fix: An agy page shows the operator's prompt twice: no live row to join, and the stored copy keeps agy's USER_REQUEST wrapper

### DIFF
--- a/apps/tuval/src/agy/ai-agent/paging-from-live.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/paging-from-live.unit.test.ts
@@ -20,7 +20,7 @@
  */
 
 import {describe, expect, it} from "vitest";
-import {upsertItem} from "../../ai-agent/core/index.ts";
+import {promptItem, upsertItem} from "../../ai-agent/core/index.ts";
 import {isRefusal, type TranscriptPage} from "../../ai-agent/history/index.ts";
 import type {TranscriptItem} from "../../ai-agent/ports/index.ts";
 // `rows.ts` rather than the chat barrel: the barrel re-exports `.tsx`, which the node tsconfig's
@@ -289,8 +289,7 @@ describe("paging an agy window back from its own live tail", () => {
 	 * Criterion: a prepended page doubles no turn the live tail already holds. The four rows agy's
 	 * stream minted carry the tail's ids in `alias`, so the stitch drops the page's copies of them;
 	 * the prompts and the system notice are rows the stream never minted, and they are what the page
-	 * is *for*. (The operator's prompt is held as the core's own `local:` echo, which agy never
-	 * confirms because its `user_input` step carries no text — that double is #8961, not this seam.)
+	 * is *for* — bar one the window holds the core's own `local:` echo of, which the case below is.
 	 */
 	it("stamps the live id on every stored row, so a prepended page doubles no turn the tail holds", () => {
 		// What a window holds after the restart: the stopped child's rows, restored, then the resumed
@@ -320,6 +319,48 @@ describe("paging an agy window back from its own live tail", () => {
 			`${JOIN_CID}:line:8`,
 			...ids(tail),
 		]);
+	});
+
+	/**
+	 * The other half of the same stitch, and the one agy alone needs (#8961): the operator's own turn.
+	 *
+	 * agy's `user_input` step carries no `text_delta`, so its live tail mints no `user` row for a
+	 * prompt at all — the core's `local:` echo is the only copy the window holds, and it stays `local`
+	 * for the window's whole life. There is therefore no id on either side to join on, and
+	 * `claimsLocal`'s text join is the whole of the reconciliation. It can only fire on the text the
+	 * operator actually typed, which is what `promptText` in `transcript.ts` is for: against the
+	 * stored `<USER_REQUEST>` frame the budget never spent and the page prepended a second copy of the
+	 * turn, in agy's wire markup, above the echo.
+	 */
+	it("joins a paged prompt against the local echo agy never confirmed, rather than doubling it", () => {
+		// The window's tail as a desk that sent the third turn itself holds it: the restored rows of
+		// the stopped child, then the echo the core recorded on send, then the resumed child's own row.
+		const echo = promptItem({
+			text: "Reply with only the word AGAIN and run no tools. No paths, no links.",
+			key: "send-again",
+			timestamp: 1_760_000_000_000,
+		});
+		const tail = [
+			...liveTail(fixtures.liveJoinStreamLines),
+			echo,
+			...liveTail(fixtures.liveJoinResumedStreamLines),
+		];
+
+		const page = served(joinPage(null));
+		// The stored row for that turn carries the prompt as typed, which is the only thing the join
+		// has: unwrapped it equals the echo's text exactly, frame and metadata blocks gone.
+		const storedPrompt = page.items.find((item) => item.id === `${JOIN_CID}:line:7`);
+		expect(storedPrompt?.kind === "user" ? storedPrompt.text : null).toBe(echo.text);
+
+		const merged = mergeOlder(tail, page.items);
+		expect(ids(merged)).toEqual([
+			`${JOIN_CID}:line:0`,
+			`${JOIN_CID}:line:5`,
+			`${JOIN_CID}:line:8`,
+			...ids(tail),
+		]);
+		// One copy of the turn, and it is the echo's row: the page's copy is gone, not both.
+		expect(texts(merged).filter((text) => text === echo.text)).toEqual([echo.text]);
 	});
 
 	/**

--- a/apps/tuval/src/agy/ai-agent/transcript.ts
+++ b/apps/tuval/src/agy/ai-agent/transcript.ts
@@ -180,6 +180,32 @@ const restore = (line: AgyTranscriptLine, full: AgyTranscriptLine | undefined): 
 
 const marked = (text: string, clipped: boolean): string => (clipped ? text + CLIPPED_MARK : text);
 
+/**
+ * agy's framing of the operator's turn, and where the operator's own words sit inside it.
+ *
+ * A `USER_EXPLICIT`/`USER_INPUT` line's `content` is never the prompt as typed: it is a
+ * `<USER_REQUEST>` block carrying the prompt, followed by an `<ADDITIONAL_METADATA>` block, and on
+ * a turn that changed a setting a `<USER_SETTINGS_CHANGE>` one too. The blocks after the request
+ * are dropped by construction — only the request's own body is read.
+ */
+const USER_REQUEST = /^<USER_REQUEST>\n?([\s\S]*?)\n?<\/USER_REQUEST>/;
+
+/**
+ * The operator's turn as he typed it, out of the frame agy stored it in.
+ *
+ * Two things turn on unwrapping it (#8961). The row reads as his own words rather than as agy's
+ * wire framing of them; and its text becomes the text the core's still-`local` echo carries, which
+ * is the only join available to a backend whose live tail mints no `user` row at all — agy's
+ * `user_input` step carries no `text_delta`, so `claimsLocal` (`shell/chat/rows.ts`) joining on
+ * text is what keeps a paged turn from rendering a second time above the echo.
+ *
+ * Only agy's own two padding newlines are taken off the body, never a general trim: what the
+ * operator typed inside the block is his, whitespace included, and the join is against that exact
+ * text. A line carrying no `<USER_REQUEST>` block passes through unchanged — the set of blocks agy
+ * may write is not closed, so the absence of the one this reads is the only thing judged here.
+ */
+const promptText = (content: string): string => USER_REQUEST.exec(content)?.[1] ?? content;
+
 /** An item and the two numbers that order it: `step_index` first, file position to break the tie. */
 interface Placed {
 	readonly item: TranscriptItem;
@@ -343,7 +369,7 @@ export const transcriptProjection = (
 
 		if (line.source === "USER_EXPLICIT" && line.type === "USER_INPUT") {
 			join(ownLiveId, id);
-			push(here, userItem(id, timestamp, marked(content, clipped.has("content"))));
+			push(here, userItem(id, timestamp, marked(promptText(content), clipped.has("content"))));
 			return;
 		}
 

--- a/apps/tuval/src/agy/ai-agent/transcript.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/transcript.unit.test.ts
@@ -326,6 +326,56 @@ describe("the agy transcript reader", () => {
 	});
 });
 
+/**
+ * The frame agy stores the operator's turn in, and the reason it comes off (#8961).
+ *
+ * The cases run over the v1.2.0 capture rather than a restated line: the wrapper is agy's, it ships
+ * no schema, and the blocks it adds are exactly what a reconstruction would smooth over — the first
+ * turn's line carries a `<USER_SETTINGS_CHANGE>` block the other two do not.
+ */
+describe("the operator's own turn, out of agy's <USER_REQUEST> frame", () => {
+	const capturedPrompts = (): ReadonlyArray<string> =>
+		transcriptItems(
+			fixtures.liveJoinConversationId,
+			transcriptLines(fixtures.liveJoinLines.join("\n")),
+			transcriptLines(fixtures.liveJoinFullLines.join("\n")),
+		)
+			.filter((item) => item.kind === "user")
+			.map((item) => item.text);
+
+	it("mints the bare prompt for every turn the capture holds, settings-change block and all", () => {
+		expect(capturedPrompts()).toEqual([
+			"In ONE single planner step, issue TWO parallel view_file tool calls: the first on one.txt and the second on two.txt. Then reply with ONLY the two line counts as bare digits separated by a comma. Write no file names, no paths, no links, no URLs in your reply.",
+			"Now reply with only the word DONE and run no tools. No paths, no links.",
+			"Reply with only the word AGAIN and run no tools. No paths, no links.",
+		]);
+	});
+
+	it("leaves no block of agy's framing in the row, which is what the operator would read", () => {
+		for (const prompt of capturedPrompts()) {
+			expect(prompt).not.toContain("USER_REQUEST");
+			expect(prompt).not.toContain("ADDITIONAL_METADATA");
+			expect(prompt).not.toContain("USER_SETTINGS_CHANGE");
+		}
+	});
+
+	it("passes a line carrying no wrapper through unchanged, since the block set is not closed", () => {
+		const bare =
+			'{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-09-03T04:17:43Z","content":"list the files in this workspace"}';
+		expect(texts(itemsOf([bare]))).toEqual(["list the files in this workspace"]);
+	});
+
+	it("serves a clipped turn framed rather than half-unwrapped, marked as the clip it is", () => {
+		// The close tag is in the part agy cut, so there is no body to read: the frame stands, and the
+		// mark says why. Half a wrapper rendered as the prompt would read as the prompt.
+		const clipped =
+			'{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-09-03T04:17:43Z","content":"<USER_REQUEST>\\nlist the files in this","truncated_fields":["content"]}';
+		expect(texts(itemsOf([clipped]))).toEqual([
+			`<USER_REQUEST>\nlist the files in this${CLIPPED_MARK}`,
+		]);
+	});
+});
+
 describe("the agy transcript page", () => {
 	const conversation = [
 		fixtures.userInput,


### PR DESCRIPTION
A paged agy turn rendered the operator's prompt twice: once as the core's local echo, once as the
page's stored copy — and that copy showed agy's wire framing rather than what he typed.

`transcript.ts` took the `USER_EXPLICIT`/`USER_INPUT` line's `content` verbatim, and agy never
stores the prompt as typed: it stores a `<USER_REQUEST>` block carrying the prompt, then an
`<ADDITIONAL_METADATA>` block, and on a turn that changed a setting a `<USER_SETTINGS_CHANGE>` one
too. The reader now unwraps the request body and drops the blocks after it. That is the right
rendering on its own — the row reads as the operator's words — and it is also the whole join: agy's
`user_input` step carries no `text_delta`, so its live tail mints no `user` row for a prompt at all
and the core's `local:` echo is the only copy the window holds. With no id on either side,
`claimsLocal`'s text join in `shell/chat/rows.ts` is the only reconciliation available, and it can
only fire on the text the operator actually typed. `rows.ts` is unchanged.

Only agy's own two padding newlines come off the body, never a general trim — what the operator
typed inside the block is his, whitespace included, and the join is against that exact text. A line
carrying no `<USER_REQUEST>` block passes through unchanged, because the set of blocks agy may write
is not closed. A clipped line whose close tag was cut keeps its frame and its clip mark rather than
being half-unwrapped; half a wrapper rendered as a prompt would read as the prompt.

Fixes #8961

## Verification

Both new unit tests were confirmed red against the unwrap reverted, so they guard the fix rather
than describe it.

- `transcript.unit.test.ts` — the minted text is the bare prompt for all three turns of the real
  v1.2.0 capture (`fixtures/live-join-transcript.jsonl`), including the first turn's line that also
  carries `<USER_SETTINGS_CHANGE>`; no framing block survives in any row; an unwrapped line and a
  clipped one keep their current answers.
- `paging-from-live.unit.test.ts` — `mergeOlder` over the shipped reader and the core's own
  `promptItem`: the stored row's text equals the echo's, the page's copy of that turn is dropped,
  and exactly one row of that text survives the prepend. The existing case above it asserted the
  same page keeps `line:7`; with the echo held it no longer does, which is the double closing.
- Hand-verification on real agy logs (the #7306 no-preview exception — tuval has no review-ui
  preview surface): the shipped reader run over this machine's own untouched agy brain directory —
  130 conversations, 613 stored user rows, 106 of them carrying a `<USER_SETTINGS_CHANGE>` block.
  Before: 613 of 613 `content` values begin `<USER_REQUEST>`. After: 0 of 613 minted rows contain
  any of the three block names. Samples read as plain prompts.
- `pnpm typecheck:affected` and `pnpm lint:worktree` green in this tree; the whole `@kampus/tuval`
  unit project green (3,264 tests).

## Deviations

- **Scope narrowing** — **Said:** #8961's fifth criterion asks for hand-verification on a real agy
  desk: page in a turn the operator sent and watch the prompt render once. **Did:** verified the two
  halves separately instead — "as typed, no wrapper markup" over 130 real conversations on this
  machine's own agy logs through the shipped reader, and "renders once" as the `mergeOlder` case
  built from the shipped reader plus the core's own `promptItem`. **Why:** driving a live Tuval desk
  against an agy child is not reachable from this lane, and the log read is the broader evidence for
  the half it covers — 613 rows against one desk's one turn. **Disposition:** stated here; the
  measurements are in Verification above, and a desk read by a human would add only the render.
