### PR TITLE
chore: StopClaim.release takes no handle, so it can clear a claim that is not the caller's

### DIFF
--- a/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
+++ b/apps/tuval/src/agy/ai-agent/AgyAiAgent.ts
@@ -576,7 +576,7 @@ const make = (options: AgyAiAgentOptions): Effect.Effect<TuvalAiAgentApi, never,
 				// with it: one that was never delivered must not speak for whatever ends this child.
 				Effect.catch((refusal) =>
 					Effect.gen(function* () {
-						yield* stop.release;
+						yield* stop.release(current.child.handle);
 						const live = yield* Ref.get(turnLive);
 						yield* publish([{kind: "failure", failure: interruptFailureOf(refusal, live)}]);
 						return false;

--- a/apps/tuval/src/agy/ai-agent/stop-claim.ts
+++ b/apps/tuval/src/agy/ai-agent/stop-claim.ts
@@ -30,8 +30,13 @@ export interface StopClaim {
 	 * one it did not.
 	 */
 	readonly heldBy: (handle: ChildProcessSpawner.ChildProcessHandle) => Effect.Effect<boolean>;
-	/** Give the claim back, for a signal the backend refused: one never delivered speaks for nothing. */
-	readonly release: Effect.Effect<void>;
+	/**
+	 * Give back this child's claim, for a signal the backend refused: one never delivered speaks
+	 * for nothing. Named to its child like the other two, and it clears only that child's claim: a
+	 * release for a child the stop no longer names is a no-op, not a theft of the claim a later child
+	 * holds.
+	 */
+	readonly release: (handle: ChildProcessSpawner.ChildProcessHandle) => Effect.Effect<void>;
 }
 
 export const makeStopClaim: Effect.Effect<StopClaim> = Effect.map(
@@ -40,6 +45,6 @@ export const makeStopClaim: Effect.Effect<StopClaim> = Effect.map(
 		claim: (handle) =>
 			Ref.modify(held, (current) => (current === handle ? [false, current] : [true, handle])),
 		heldBy: (handle) => Effect.map(Ref.get(held), (current) => current === handle),
-		release: Ref.set(held, null),
+		release: (handle) => Ref.update(held, (current) => (current === handle ? null : current)),
 	}),
 );

--- a/apps/tuval/src/agy/ai-agent/stop-claim.unit.test.ts
+++ b/apps/tuval/src/agy/ai-agent/stop-claim.unit.test.ts
@@ -77,7 +77,7 @@ describe("the claim a stop takes on one child", () => {
 			const child = handle(1);
 
 			yield* stop.claim(child);
-			yield* stop.release;
+			yield* stop.release(child);
 
 			assert.isFalse(yield* stop.heldBy(child), "a refused signal went on speaking for the child");
 			assert.isTrue(
@@ -100,6 +100,29 @@ describe("the claim a stop takes on one child", () => {
 			assert.isFalse(
 				yield* stop.heldBy(first),
 				"the stopped child still held the claim after the relaunch took it",
+			);
+		}),
+	);
+
+	it.effect("releases its own child only, leaving a later claim standing", () =>
+		Effect.gen(function* () {
+			const stop = yield* makeStopClaim;
+			const first = handle(1);
+			const second = handle(2);
+
+			yield* stop.claim(first);
+			yield* stop.claim(second);
+			yield* stop.release(first);
+
+			assert.isTrue(
+				yield* stop.heldBy(second),
+				"a release named to the stopped child took the relaunched child's claim with it",
+			);
+
+			yield* stop.release(second);
+			assert.isFalse(
+				yield* stop.heldBy(second),
+				"the release named to the child that held the stop left it in flight",
 			);
 		}),
 	);


### PR DESCRIPTION
`StopClaim` keyed `claim` and `heldBy` to a child handle and left `release` unkeyed, so a caller
holding child B could clear child A's in-flight stop. Nothing was wrong at runtime — the one call
site releases the child it claimed on two lines earlier — but the module exists to make that misuse
unspellable, and this was the last member that did not name its child.

`release` now takes the handle and clears over a `Ref.update` that nulls only when
`current === handle`, the same identity test the other two members make. A release named to a child
the stop no longer names is a no-op, not a theft of the claim a later child holds. The `interrupt`
refusal path in `AgyAiAgent.ts` passes `current.child.handle`, the handle it claimed on.

The new case in `stop-claim.unit.test.ts` claims two children, releases the first, and asserts the
second's claim stands; a matching release clears it. Checked for falsifiability: with `release`
restored to the old unconditional `Ref.set(held, null)` that case reds on its own message, and it
greens on the fix.

Fixes #8971

## Deviations

None.
