### PR TITLE
chore: check-epic-plan's doc says a command never fails; it can fail four ways

### DIFF
--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -87,7 +87,10 @@ approval bound to the scope it now derives:
 fabrika plan approval $epic_number
 ```
 
-It exits `0` on every arm and the answer's `state` is the discriminator — `current`, `stale` or
+It exits `0` on every **state** arm — `current`, `stale` or `absent` — and that `state` is the
+discriminator; a missing approval is this verb's answer, not a refusal. It still refuses non-zero on
+everything else (`4`, `7`, `10`, `11` and the reserved codes), and a refusal is not a fourth state:
+the opening UNKNOWN rule holds, so read the code, then re-run or stop, and never read one as
 `absent`. Only `current` proceeds to step 2. On `stale` or `absent` end at `PLAN-UNAPPROVED`,
 **naming which**: `absent` means nobody with authority has approved this plan, `stale` means the plan
 moved after he read it and a re-plan does not inherit the old approval. You never write the marker


### PR DESCRIPTION
`check-epic-plan/SKILL.md` told the reader that `fabrika plan approval` "exits `0` on every arm",
three lines above the instruction to branch on the answer's `state`. The verb also refuses on `4`,
`7`, `10` and `11`. The intended claim was about the *state* arms — a missing approval is the verb's
answer, not a refusal — and the qualifier had been dropped.

The block now scopes the claim to the three state arms, names the non-zero refusals, and points at
the skill's own opening UNKNOWN rule for what to do on one, so the state-versus-refusal split is
written down instead of rescued by a global rule. The wording matches `contract.md`'s shared exit
matrix (`approval` column: `0`, `1`, `4`, `7`, `10`, `11`, `126`, `127`) and `approval-verb.ts`'s
docblock; no third phrasing of the fact is introduced.

Docs only. Nothing under `packages/fabrika-cli/src/plan/` is touched and no exit code moves.

Fixes #6659

## Deviations

None.
