### PR TITLE
fix: A commit that only mentions #N can unblock an epic child whose work never landed

### DIFF
--- a/.decisions/0301-blocked-by-graph-is-the-carrier.md
+++ b/.decisions/0301-blocked-by-graph-is-the-carrier.md
@@ -275,3 +275,20 @@ no vocabulary impact
 > **What does not move.** The graph is still the one carrier, `status:blocked` stays retired, the
 > purpose matrix stands as written, and discharge still only ever admits. What changes is that the
 > per-child edge stops being something a planner may or may not think to write.
+
+> Amendment 2026-09-10 — **a mention is not a landing.** The 2026-08-29 amendment above names
+> `issueRefsIn` as the rule that discharges an edge off the assembly branch. That matcher reads a
+> bare `#<n>` anywhere in a message, so a commit the run itself put on `epic/<parent>` saying
+> `refactor(tracer): rework the helper; does not touch #6008` discharged #6008's edge and a child
+> lane started against a predecessor that does not exist. The rule is now `landingRefsIn`
+> (`packages/fabrika-cli/src/build/commit-message.ts`), which recognises three shapes and nothing
+> else: a subject's trailing `(#<n>)`, a line-anchored `Closes`/`Fixes`/`Resolves`/`Part of` trailer,
+> and the ref inside the `Merge branch 'build/<n>-…'` subject `lane integrate` writes. It sits beside
+> `issueRefsIn` rather than narrowing it, because `lane prove` and `build commit`'s foreign-ref
+> refusal both want the loose read.
+>
+> **What does not move.** Discharge still only ever admits, the range is still
+> `<merge base with the trunk>..epic/<parent>`, and the two bounds stay independent — the range says
+> which commits may speak, the landing rule says what counts as speaking. Recognition failure is
+> silence, never a landing: an unrecognised shape leaves the edge as the board reads it and the gate
+> refuses. Filed against [#7238](https://github.com/kamp-us/phoenix/issues/7238).

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -643,7 +643,7 @@ assembly branch is in the pool, and the branch read that put it there is on stde
 $ fabrika build pick
 build pick: scanned p0 0, p1 1, p2 0 in owner/repo; 1 candidate(s) survived the filter, 0 excluded — 0 by the admission test, 0 for no acceptance-criteria block, 0 on the blocked_by graph.
 build pick: campaigns: 1 active — Search rewrite (#7).
-build pick: origin/main..epic/3 adds a commit naming #9 — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.
+build pick: origin/main..epic/3 adds a commit that lands #9 — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.
 {"pool":[{"number":30,"title":"The second tracer","priority":"p1","type":"chore","home":"7"}],"excluded":{},"scanned":{"p0":0,"p1":1,"p2":0},"campaigns":{"state":"active","milestones":["7"]}}
 ```
 
@@ -710,19 +710,26 @@ the assembly-branch discharge below is named from it and the answer carries it.
 
 **A blocker is discharged from two sources, and the second one is git.** It is
 discharged when its issue is closed **or** when the parent epic's assembly branch, `epic/<parent>`,
-carries a commit whose message names it. An epic run is one branch and one PR, so no
+carries a commit whose message says it *landed* it. An epic run is one branch and one PR, so no
 child issue closes until the tail PR merges — reading only the closed state would make every
 later-phase child of a run in flight permanently blocked, on a gate that cannot be satisfied
 before the epic it blocks has shipped. The branch name is derived from the parent's number, never
-taken from a caller, and the message is read with the same `#<n>` rule `build commit` and
-`lane prove` use.
+taken from a caller.
+
+**A mention is not a landing.** The message is read with `landingRefsIn`, which knows three shapes
+and nothing else: a subject's trailing `(#<n>)`, a line-anchored `Closes`/`Fixes`/`Resolves`/`Part
+of` trailer, and the ref inside the `Merge branch 'build/<n>-…'` subject `lane integrate` writes.
+Reading the looser `#<n>`-anywhere rule `build commit` and `lane prove` use let
+`refactor(tracer): rework the helper; does not touch #<n>` discharge that number's edge.
+Recognition runs one way only: a shape the rule does not know is no evidence, so the edge keeps the
+board's state and the gate refuses.
 
 **"Carries" is the run's own commits, and the range is stated in every line the verb prints**:
 `<merge base with the trunk>..epic/<parent>`, the two-dot shape `lane prove` locates a child's range
 with, where the trunk is `origin/<the repo's default branch>`. Not everything reachable from the
-branch tip — that set is the whole trunk history the branch was cut from, and since the `#<n>` rule
-matches a bare mention anywhere in a message, an old commit writing "blocked on #<n>" would
-discharge an edge whose work was never built.
+branch tip — that set is the whole trunk history the branch was cut from, where an old commit
+closing its own `#<n>` would discharge an edge this run never built. The two bounds are independent:
+the range says which commits may speak, the landing rule says what counts as speaking.
 
 The second source only ever discharges, and only on evidence it read: a branch this tree does not
 carry, a trunk this repo would not name, no merge base, or a git read that failed, leaves every edge
@@ -760,8 +767,8 @@ when every blocker's state is known.
 | `build eligible: <n> blockers could not be read — eligibility is UNKNOWN, never "eligible".` | 11 | refusal |
 | `build eligible: cannot read blocker #<m>: <reason> — its state is UNKNOWN, never counted closed.` | 11 or 16 | detail line, one per unread blocker |
 | `build eligible: blocked by <n> open blocked_by edges: #<m>, #<k>.` | 16 | refusal |
-| `build eligible: origin/<trunk>..epic/<p> adds a commit naming #<m> — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.` | 0, 11 or 16 | detail line, once |
-| `build eligible: origin/<trunk>..epic/<p> adds <n> commit(s), none naming an undischarged blocker.` | 11 or 16 | detail line, once |
+| `build eligible: origin/<trunk>..epic/<p> adds a commit that lands #<m> — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.` | 0, 11 or 16 | detail line, once |
+| `build eligible: origin/<trunk>..epic/<p> adds <n> commit(s), none landing an undischarged blocker.` | 11 or 16 | detail line, once |
 | `build eligible: cannot read epic/<p> in this tree: <reason> — no edge is counted discharged off it, and every edge keeps the state the board gave it.` (`<reason>` also covers an unnameable trunk and an absent merge base — the range's other two endpoints; on a shallow clone the merge-base reason carries git's own words, names the shallow clone as a likely cause and `git fetch --unshallow origin` as the remedy) | 11 or 16 | detail line, once |
 
 **Scope** — one issue, its parent (if any), every blocker its `blocked_by` list names, and —
@@ -798,7 +805,7 @@ $ echo $?
 ```
 $ fabrika build eligible 12
 build eligible: scanned 1 blocked_by edge; parent #3.
-build eligible: origin/main..epic/3 adds a commit naming #9 — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.
+build eligible: origin/main..epic/3 adds a commit that lands #9 — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.
 {"answer":"eligible","number":12,"parent":3}
 $ echo $?
 0
@@ -1123,8 +1130,8 @@ the pieces is what handed a builder an ordering decision it then got wrong.
 | `build claim: blocked by <n> open blocked_by edges: #<a>, #<b> — there is no unblock act, so the edge clears when the blocker closes or its work lands on the epic run's assembly branch; nothing was written.` — preceded by `build claim: scanned <n> blocked_by edges.` | 16 | refusal |
 | `build claim: blockedness: the gate binds a build claim only — a <purpose> claim writes no code, and authoring or checking a ledger is the work that should happen while the blocker is still open.` — printed instead of the graph read under `--purpose plan` and `--purpose gate` | 0 | detail line, once |
 | `build claim: cannot read the blocked_by edges of #<n>: <reason> — blockedness is UNKNOWN, never "not blocked"; nothing was written.` (`<reason>` also covers a parent that could not be read, which leaves the assembly-branch discharge unread) | 11 | refusal |
-| `build claim: origin/<trunk>..epic/<p> adds a commit naming #<m> — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.` | 0, 11 or 16 | detail line, once |
-| `build claim: origin/<trunk>..epic/<p> adds <n> commit(s), none naming an undischarged blocker.` | 11 or 16 | detail line, once |
+| `build claim: origin/<trunk>..epic/<p> adds a commit that lands #<m> — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.` | 0, 11 or 16 | detail line, once |
+| `build claim: origin/<trunk>..epic/<p> adds <n> commit(s), none landing an undischarged blocker.` | 11 or 16 | detail line, once |
 | `build claim: cannot read epic/<p> in this tree: <reason> — no edge is counted discharged off it, and every edge keeps the state the board gave it.` (`<reason>` also covers an unnameable trunk and an absent merge base — the range's other two endpoints; on a shallow clone the merge-base reason carries git's own words, names the shallow clone as a likely cause and `git fetch --unshallow origin` as the remedy) | 11 or 16 | detail line, once |
 | `build claim: the "## Campaigns" table does not parse: <detail> — a malformed table is never read as "nothing is active"; nothing was written.` | 4 | refusal |
 | `build claim: #<n> is already held by this lane (comment <id>) — answered with the marker that owns it; nothing was written.` — beside `{"answer":"won", …}` on exit 0, when `--token` names a lane that already holds `<n>` | 0 | answer |
@@ -1211,7 +1218,7 @@ assembly branch, so the claim is admitted rather than parked.
 $ fabrika build claim 12
 build claim: campaigns: 1 active — Search rewrite (#7).
 build claim: purpose: build — the audience axis binds; this issue carries ready-for:agent.
-build claim: origin/main..epic/3 adds a commit naming #9 — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.
+build claim: origin/main..epic/3 adds a commit that lands #9 — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.
 build claim: scanned 1 blocked_by edge; none open.
 {"answer":"won","number":12,"token":"build:s-9f2e:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d","purpose":"build"}
 ```
@@ -1220,7 +1227,7 @@ build claim: scanned 1 blocked_by edge; none open.
 $ fabrika build claim 13
 build claim: campaigns: 1 active — Search rewrite (#7).
 build claim: purpose: build — the audience axis binds; this issue carries ready-for:agent.
-build claim: origin/main..epic/3 adds 3 commit(s), none naming an undischarged blocker.
+build claim: origin/main..epic/3 adds 3 commit(s), none landing an undischarged blocker.
 build claim: scanned 1 blocked_by edge.
 build claim: blocked by 1 open blocked_by edge: #6 — there is no unblock act, so the edge clears when the blocker closes or its work lands on the epic run's assembly branch; nothing was written.
 $ echo $?

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -1747,7 +1747,7 @@ describe("runClaim — the blockedness gate", () => {
 			]);
 			expect(out.code).toBe(0);
 			expect(JSON.parse(out.stdout).answer).toBe("won");
-			expect(out.stderr.join("\n")).toContain("adds a commit naming #210");
+			expect(out.stderr.join("\n")).toContain("adds a commit that lands #210");
 		});
 
 		it("still refuses on 16 when the branch carries no commit naming the blocker", async () => {
@@ -1759,7 +1759,7 @@ describe("runClaim — the blockedness gate", () => {
 			]);
 			expect(out.code).toBe(BLOCKED);
 			expect(shell.requests.some((line) => POST.test(line))).toBe(false);
-			expect(out.stderr.join("\n")).toContain("none naming an undischarged blocker");
+			expect(out.stderr.join("\n")).toContain("none landing an undischarged blocker");
 		});
 
 		it("refuses on 16 when the branch cannot be read — never admits on unread evidence", async () => {

--- a/packages/fabrika-cli/src/build/commit-message.ts
+++ b/packages/fabrika-cli/src/build/commit-message.ts
@@ -17,6 +17,48 @@ export const issueRefsIn = (message: string): ReadonlyArray<number> =>
 		match[1] === undefined ? [] : [Number.parseInt(match[1], 10)],
 	);
 
+/** The subject's trailing `(#<n>)` — the shape the `build` skill's message convention writes. */
+const TRAILING_REF = /\(#(\d+)\)\s*$/;
+
+/**
+ * A ref a closing or association keyword introduces, and the anchor is the whole guard: the keyword
+ * must open its own line, so `does not close #<n>` is prose and `Closes #<n>` is a trailer.
+ */
+const TRAILER_REF = /^[ \t]*(?:closes?|closed|fix(?:e[sd])?|resolve[sd]?|part of)[ \t]+#(\d+)\b/gim;
+
+/** The child number inside a merged ref — `build/<n>-…` direct, `replay/build-<n>-…-onto-<sha>`. */
+const MERGED_BRANCH_REF = /(?:^|[/-])build[/-](\d+)-/g;
+
+const QUOTED_REF = /'([^']*)'/g;
+
+/**
+ * Every `#<n>` a message claims to have *landed* — a strict subset of {@link issueRefsIn}.
+ *
+ * Three shapes are recognised, and each is one the pipeline actually writes onto an assembly branch:
+ * a subject's trailing `(#<n>)`, a line-anchored `Closes`/`Fixes`/`Resolves`/`Part of` trailer, and
+ * the ref inside the `Merge branch '<ref>' into <branch>` subject `lane integrate` produces. Nothing
+ * else counts, so an incidental or negating mention names no landing — which is the whole point:
+ * `issueRefsIn` matches a bare `#<n>` anywhere, and reading that as evidence let
+ * `refactor(tracer): rework the helper; does not touch #<n>` discharge that number's dependency edge.
+ *
+ * It sits beside `issueRefsIn` rather than narrowing it, because `lane prove` and
+ * {@link foreignRefsIn} want the loose read: prove asks whether a range mentions its child at all,
+ * and the foreign-ref refusal must red on every number a message names, landing or not.
+ */
+export const landingRefsIn = (message: string): ReadonlyArray<number> => {
+	const subject = subjectOf(message);
+	const refs: number[] = [];
+	const trailing = TRAILING_REF.exec(subject);
+	if (trailing?.[1] !== undefined) refs.push(Number.parseInt(trailing[1], 10));
+	for (const trailer of message.matchAll(TRAILER_REF))
+		if (trailer[1] !== undefined) refs.push(Number.parseInt(trailer[1], 10));
+	if (/^Merge branch(?:es)? /.test(subject))
+		for (const quoted of subject.matchAll(QUOTED_REF))
+			for (const merged of (quoted[1] ?? "").matchAll(MERGED_BRANCH_REF))
+				if (merged[1] !== undefined) refs.push(Number.parseInt(merged[1], 10));
+	return refs;
+};
+
 /** The numbers a message names that `permitted` does not hold — empty is the clean message. */
 export const foreignRefsIn = (
 	message: string,

--- a/packages/fabrika-cli/src/build/commit-message.unit.test.ts
+++ b/packages/fabrika-cli/src/build/commit-message.unit.test.ts
@@ -4,6 +4,7 @@ import {
 	foreignRefsIn,
 	isLaneScratchLeaf,
 	issueRefsIn,
+	landingRefsIn,
 	leafOf,
 	quotedBlock,
 	redact,
@@ -25,6 +26,44 @@ describe("issueRefsIn", () => {
 
 	it("does not read a colour, a heading or a trailing hash as an issue reference", () => {
 		expect(issueRefsIn("style: use #fff for the rule\n\n# Notes\n")).toEqual([]);
+	});
+});
+
+describe("landingRefsIn", () => {
+	it("reads the subject's trailing (#<n>), the shape `build commit`'s convention writes", () => {
+		expect(landingRefsIn("fix(report): state the guarantee (#4789)")).toEqual([4789]);
+	});
+
+	it("reads a line-anchored closing or association trailer", () => {
+		expect(landingRefsIn("feat(guide): the front door\n\nCloses #6004\nPart of #5817\n")).toEqual([
+			6004, 5817,
+		]);
+	});
+
+	// The shape `lane integrate` writes onto `epic/<N>`, read off git's own default merge message.
+	it("reads the child number out of the merge subject integrate produces", () => {
+		expect(
+			landingRefsIn("Merge branch 'build/4312-editor-focus-loss-c4367b0b' into epic/4300"),
+		).toEqual([4312]);
+	});
+
+	it("reads a replayed ref too, which carries the child branch with its slashes flattened", () => {
+		expect(
+			landingRefsIn(
+				"Merge branch 'replay/build-4312-editor-focus-loss-c4367b0b-onto-abc1234' into epic/4300",
+			),
+		).toEqual([4312]);
+	});
+
+	// The defect this predicate exists to close: `issueRefsIn` reads a landing from both.
+	it("reads no landing from an incidental or a negating mention", () => {
+		expect(landingRefsIn("refactor(tracer): rework the helper; does not touch #6008")).toEqual([]);
+		expect(landingRefsIn("chore(build): drop the change that would have closed #6008")).toEqual([]);
+	});
+
+	// Recognition runs one way only, so a shape it does not know is silence, never a landing.
+	it("reads no landing from a shape it does not recognise", () => {
+		expect(landingRefsIn("wip on #6008")).toEqual([]);
 	});
 });
 

--- a/packages/fabrika-cli/src/build/discharge.ts
+++ b/packages/fabrika-cli/src/build/discharge.ts
@@ -82,9 +82,11 @@ export const assemblyNotes = (verb: string, discharge: Discharge): ReadonlyArray
 	}
 	const range = `${assembly.baseRef}..${assembly.branch}`;
 	return discharged.length === 0
-		? [`${verb}: ${range} adds ${assembly.commits} commit(s), none naming an undischarged blocker.`]
+		? [
+				`${verb}: ${range} adds ${assembly.commits} commit(s), none landing an undischarged blocker.`,
+			]
 		: [
-				`${verb}: ${range} adds a commit naming ${discharged.map((blocker) => `#${blocker}`).join(", ")} — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.`,
+				`${verb}: ${range} adds a commit that lands ${discharged.map((blocker) => `#${blocker}`).join(", ")} — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue.`,
 			];
 };
 

--- a/packages/fabrika-cli/src/build/discharge.unit.test.ts
+++ b/packages/fabrika-cli/src/build/discharge.unit.test.ts
@@ -59,7 +59,7 @@ describe("readDischargedGate", () => {
 			[ASSEMBLY_LOG, commitLog(`feat(tracer): the first tracer (#${BLOCKER_NUMBER})`)],
 		]);
 		expect(out.gate).toEqual({_tag: "Clear", scanned: 1});
-		expect(out.notes.join("\n")).toContain(`adds a commit naming #${BLOCKER_NUMBER}`);
+		expect(out.notes.join("\n")).toContain(`adds a commit that lands #${BLOCKER_NUMBER}`);
 	});
 
 	it("still blocks an open edge the branch does not carry — discharge only ever admits", async () => {
@@ -70,7 +70,7 @@ describe("readDischargedGate", () => {
 			[ASSEMBLY_LOG, commitLog("chore(epic): assembly branch cut (#6768)")],
 		]);
 		expect(out.gate).toEqual({_tag: "Blocked", scanned: 1, open: [BLOCKER_NUMBER]});
-		expect(out.notes.join("\n")).toContain("none naming an undischarged blocker");
+		expect(out.notes.join("\n")).toContain("none landing an undischarged blocker");
 	});
 
 	it("keeps the board's state when the assembly branch cannot be read", async () => {

--- a/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
@@ -218,7 +218,7 @@ describe("runEligible", () => {
 			]);
 			expect(out.code).toBe(0);
 			expect(JSON.parse(out.stdout)).toEqual({answer: "eligible", number: 4312, parent: 4300});
-			expect(out.stderr.at(-1)).toContain("origin/main..epic/4300 adds a commit naming #210");
+			expect(out.stderr.at(-1)).toContain("origin/main..epic/4300 adds a commit that lands #210");
 		});
 
 		it("reads no branch at all when every blocker is already closed", async () => {

--- a/packages/fabrika-cli/src/build/landed.ts
+++ b/packages/fabrika-cli/src/build/landed.ts
@@ -7,28 +7,34 @@
  * the one a dependency gate means.
  *
  * The evidence is the git graph, never the lane's own fold — a machine's self-report is not
- * evidence, which is why `lane prove` reads commits too. The ref-matching rule is
- * {@link issueRefsIn}, the same one `build commit` and `lane prove` read messages with, so a
- * predecessor cannot be discharged here by a spelling nothing else recognises.
+ * evidence, which is why `lane prove` reads commits too.
  *
- * **The read is the run's own commits, never everything reachable from the branch tip.** The set is
- * `<merge base with the trunk>..epic/<N>`, the two-dot shape `lane prove` locates a child's range
- * with. A one-dot walk sweeps in the whole trunk history the branch was cut from, and since
- * `issueRefsIn` matches a bare `#<n>` anywhere in a message, a years-old commit writing "blocked on
- * #<n>" would then discharge an edge whose work was never built — the fail-open `build eligible`
- * exists to remove.
+ * **A mention that is not a landing cannot discharge.** The rule is {@link landingRefsIn}, which
+ * recognises only the three message shapes the pipeline writes onto an assembly branch — a subject's
+ * trailing `(#<n>)`, a line-anchored closing trailer, and `lane integrate`'s
+ * `Merge branch 'build/<n>-…'`. `issueRefsIn` matches a bare `#<n>` anywhere, so reading *it* as
+ * evidence let `refactor(tracer): rework the helper; does not touch #<n>` discharge that number's
+ * edge. Recognition runs one way only: a shape the rule does not know is no evidence, so the edge
+ * keeps the board's state and the gate refuses.
+ *
+ * **The read is also the run's own commits, never everything reachable from the branch tip.** The
+ * set is `<merge base with the trunk>..epic/<N>`, the two-dot shape `lane prove` locates a child's
+ * range with. A one-dot walk sweeps in the whole trunk history the branch was cut from, where a
+ * years-old commit closing its own `#<n>` would discharge an edge this run never built. The two
+ * bounds are independent: the range says which commits may speak, the landing rule says what
+ * counts as speaking.
  */
 import {Effect} from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {mergeBase, noMergeBaseReason, rangeCommits, resolveCommit} from "../io/git.ts";
 import {epicBranch} from "../wire/lane-brief.ts";
-import {issueRefsIn} from "./commit-message.ts";
+import {landingRefsIn} from "./commit-message.ts";
 import {defaultBranch} from "./github.ts";
 
-/** Every issue number these commit messages name — the set whose work this branch carries. */
+/** Every issue number these commit messages claim to land — the set whose work this branch carries. */
 export const landedRefs = (messages: ReadonlyArray<string>): ReadonlySet<number> =>
-	new Set(messages.flatMap((message) => [...issueRefsIn(message)]));
+	new Set(messages.flatMap((message) => [...landingRefsIn(message)]));
 
 /**
  * What the assembly branch said, or why it said nothing.

--- a/packages/fabrika-cli/src/build/landed.unit.test.ts
+++ b/packages/fabrika-cli/src/build/landed.unit.test.ts
@@ -6,18 +6,40 @@ import {GATEWAY, GH_TOKEN_ENV, served} from "./fixtures.test-support.ts";
 import {landedRefs, readAssembly} from "./landed.ts";
 
 describe("landedRefs", () => {
-	it("reads every issue a message names, subject and body alike", () => {
+	it("reads every issue a message claims to land, subject and body alike", () => {
 		expect([
 			...landedRefs(["feat(guide): the front door (#6004)\n\nPart of #5817", "chore: nothing"]),
 		]).toEqual([6004, 5817]);
+	});
+
+	// The merge `lane integrate` makes is the only commit the assembly seat itself authors, and
+	// `build commit`'s foreign-ref refusal never reads it — so it is the live entry path for a
+	// false landing.
+	it("reads the child out of integrate's merge commit", () => {
+		expect([
+			...landedRefs(["Merge branch 'build/6008-focus-steal-c4367b0b' into epic/4300"]),
+		]).toEqual([6008]);
 	});
 
 	it("is empty for a branch that carries no commit", () => {
 		expect(landedRefs([]).size).toBe(0);
 	});
 
-	// The same rule `build commit` and `lane prove` read messages with, so a number written without
-	// its `#` is not a reference — a discharge off "issue 210" would be a discharge off prose.
+	// `issueRefsIn` read both of these as landings, so the discharge subtracted an edge whose blocker
+	// was never built and the next child built against missing code.
+	it("does not read a landing from an incidental mention", () => {
+		expect(landedRefs(["refactor(tracer): rework the helper; does not touch #6008"]).size).toBe(0);
+	});
+
+	it("does not read a landing from a negating mention", () => {
+		expect(landedRefs(["chore: revert the commit that would have closed #6008"]).size).toBe(0);
+	});
+
+	// Recognition failure never admits: an unknown shape leaves the edge as the board reads it.
+	it("does not read a landing from a shape the rule does not recognise", () => {
+		expect(landedRefs(["wip: halfway through #6008"]).size).toBe(0);
+	});
+
 	it("does not read a bare number as a reference", () => {
 		expect(landedRefs(["fix: closes issue 210"]).size).toBe(0);
 	});
@@ -38,8 +60,8 @@ const script: ReadonlyArray<Scripted> = [
 describe("readAssembly", () => {
 	/**
 	 * The bound is the finding this module was repaired for: a one-dot walk sweeps in the whole trunk
-	 * history the assembly branch was cut from, and `issueRefsIn` matching a bare `#<n>` anywhere would
-	 * then discharge an edge off a commit that predates the epic.
+	 * history the assembly branch was cut from, where a commit that predates the epic and closes its
+	 * own number would discharge an edge this run never built.
 	 */
 	it("walks only what the branch adds over its merge base with the trunk", async () => {
 		const seams = fakeSeams(script);
@@ -48,6 +70,26 @@ describe("readAssembly", () => {
 		);
 		expect(read).toMatchObject({_tag: "Read", branch: "epic/4300", baseRef: "origin/main"});
 		expect(seams.calls.some((line) => line.endsWith(`${BASE}..${TIP}`))).toBe(true);
+		expect(read._tag === "Read" ? [...read.landed] : []).toEqual([210]);
+	});
+
+	/**
+	 * The range bound and the landing rule are independent halves of one invariant, so a commit the
+	 * run itself put on the branch still discharges nothing unless it says it landed the work.
+	 */
+	it("carries no landing off an in-range commit that only mentions a number", async () => {
+		const seams = fakeSeams([
+			...script.slice(0, 3),
+			[
+				/^git log /,
+				okOut(`${TIP}\x1frefactor(tracer): rework the helper; does not touch #210\x1e`),
+			],
+		] as ReadonlyArray<Scripted>);
+		const read = await Effect.runPromise(
+			Effect.provide(readAssembly(GH_TOKEN_ENV, "o/r", 4300), seams.layer),
+		);
+		expect(read).toMatchObject({_tag: "Read", commits: 1});
+		expect(read._tag === "Read" ? read.landed.size : -1).toBe(0);
 	});
 
 	/**

--- a/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
@@ -499,7 +499,7 @@ describe("runPick — the blocked_by graph", () => {
 			expect(out.code).toBe(0);
 			expect(pool(out).map((row) => row.number)).toEqual([CHILD]);
 			expect(excluded(out)).toEqual({});
-			expect(out.stderr.join("\n")).toContain(`adds a commit naming #${BLOCKER}`);
+			expect(out.stderr.join("\n")).toContain(`adds a commit that lands #${BLOCKER}`);
 		});
 
 		it("still excludes an open edge the branch does not carry — discharge only ever admits", async () => {


### PR DESCRIPTION
The assembly-branch discharge (ADR 0285 / ADR 0301) subtracted a `blocked_by` edge whenever any
commit in `<merge base with trunk>..epic/<N>` named the blocker's number. The matcher was
`issueRefsIn`, which matches a bare `#<n>` anywhere in a message, so a commit that merely mentioned a
number — including one saying the work was *not* done — cleared the edge. That is fail-open: the next
child starts against a predecessor that never landed, and the failure shows up later as a build
against missing code rather than as a refusal.

**The fix is a new predicate, not a narrowing of the shared matcher.** `landingRefsIn` sits beside
`issueRefsIn` in `packages/fabrika-cli/src/build/commit-message.ts` and recognises three shapes:

- a subject's trailing `(#<n>)` — the `build` skill's message convention;
- a line-anchored `Closes` / `Fixes` / `Resolves` / `Part of` trailer, where the line anchor is the
  guard that keeps `does not close #<n>` prose;
- the ref inside the `Merge branch 'build/<n>-…' into epic/<N>` subject `lane integrate` writes.

`lane prove` and `foreignRefsIn` keep the loose read untouched, so the foreign-ref refusal still reds
on every number a message names and prove still asks whether a range mentions its child at all.

**Grounded, not assumed.** The merge-commit shape was read off a real no-fast-forward merge of a
`build/<n>-<slug>-<nonce>` branch into `epic/<N>` in a throwaway repository, because
`packages/fabrika-cli/src/lane/integrate-verb.ts` passes no message flag and the tool composes the
subject itself. That merge also keeps the child's own commits inside the range, so the branch-name
read is a second recogniser rather than the only one — which is what keeps the strict rule from
re-opening the sequential-epic park that #7035 exists to close.

Recognition runs one way only: a shape the rule does not know is no evidence, so the edge keeps the
board's state and the gate refuses.

The two verbs' printed grammar moved with it — `adds a commit naming #<m>` → `adds a commit that
lands #<m>`, and `none naming an undischarged blocker` → `none landing an undischarged blocker` —
swept across the source, `contract.md`'s Output tables and worked examples, and the tests that assert
each line. ADR 0301 carries a dated amendment recording the narrowing.

Fixes #7238

## Deviations

- **Out-of-scope change** — **Said:** the issue scopes the fix to `landed.ts`, `commit-message.ts`
  and `landed.unit.test.ts`. **Did:** also changed the diagnostic line
  `packages/fabrika-cli/src/build/discharge.ts` prints, plus its copies in
  `claude-plugins/fabrika/skills/build/contract.md` and in the `eligible` / `claim` / `pick` /
  `discharge` unit tests. **Why:** the old line reads "adds a commit naming #<m>", which is exactly
  the rule this PR stops enforcing — leaving it would make the verb assert something false about its
  own answer. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the acceptance criteria name no decision record. **Did:**
  appended a dated amendment to `.decisions/0301-blocked-by-graph-is-the-carrier.md`. **Why:** its
  2026-08-29 amendment names `issueRefsIn` as the discharge rule by name, so the record would
  contradict the code. **Disposition:** stated here.
- **Declined guidance** — **Said:** criterion 1 names an "incidental or negating mention".
  **Did:** detected both by message shape only, adding no negation heuristic. **Why:** a trailing
  `(#<n>)` on a genuinely negating subject would still read as a landing, but detecting English
  negation is a heuristic that fails closed and re-opens the sequential-epic park #7035 exists to
  close. **Disposition:** stated here.
