### PR TITLE
feat: Closing an epic child leaves the epic's dependency list stale and no command fixes it

### DIFF
--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -446,10 +446,10 @@ absent or non-conforming. `topology` is the imported `readTopology` parse. `cycl
 
 | Code | Trigger |
 |---|---|
-| `4` | the epic body's `## Dependencies` is `Unparseable`; a ledger section appears more than once; a child's `**Stories:**` or `**Containment:**` field line appears more than once; or a **non-empty** `### User stories` list is not contiguous from 1 | ✓ |
-| `7` | the epic is proven absent (404) or closed, or it has zero sub-issue children | ✓ |
-| `10` | the issue is not a `type:epic` | ✓ |
-| `11` | the epic, the sub-issue list, or a child could not be read (when this was written this row also named the `product-development-cycle.md` probe, so the premise is stale and the conclusion is not — the probe is total and answers `unknown` on a failed read, which the output schema above carries and `plan check` names in `skipped`; `11` stays reachable by the three reads named here) | ✓ |
+| `4` | the epic body's `## Dependencies` is `Unparseable`; a ledger section appears more than once; a child's `**Stories:**` or `**Containment:**` field line appears more than once; or a **non-empty** `### User stories` list is not contiguous from 1 |
+| `7` | the epic is proven absent (404) or closed, or it has zero sub-issue children |
+| `10` | the issue is not a `type:epic` |
+| `11` | the epic, the sub-issue list, or a child could not be read (when this was written this row also named the `product-development-cycle.md` probe, so the premise is stale and the conclusion is not — the probe is total and answers `unknown` on a failed read, which the output schema above carries and `plan check` names in `skipped`; `11` stays reachable by the three reads named here) |
 
 An **absent** `## Dependencies` block is *not* `4` — it is defect `MISSING_DEPS_SECTION`, which
 `plan check` derives. `4` is the unparseable, duplicated and mis-numbered cases only.
@@ -545,13 +545,11 @@ trusted a caller-supplied ledger would grade a document the caller could edit.
 
 | Code | Trigger |
 |---|---|
-| `4` | the ledger grammar refused, exactly as `plan read` | ✓ |
-| `7` | zero scope — the epic is proven absent or closed, or it has zero children | ✓ |
-| `10` | the issue is not a `type:epic` | ✓ |
-| `11` | any read the floor depends on failed — nothing is graded, and no verdict is implied; the control-plane roster is one such read, so an unreadable roster is `11` and never `25` | ✓ |
-| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — refused **before** the floor is derived | — |
-| `26` | proven: the epic body's `## Dependencies` region has no single meaning — it carries more than one heading, or its only one resolves inside the preserved brief envelope | — | — | — | — | — | — | ✓ |
-| `27` | proven: every issue the topology names closed without landing, so restaging would leave no phase at all — re-plan the epic instead | — | — | — | — | — | — | ✓ |
+| `4` | the ledger grammar refused, exactly as `plan read` |
+| `7` | zero scope — the epic is proven absent or closed, or it has zero children |
+| `10` | the issue is not a `type:epic` |
+| `11` | any read the floor depends on failed — nothing is graded, and no verdict is implied; the control-plane roster is one such read, so an unreadable roster is `11` and never `25` |
+| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — refused **before** the floor is derived |
 
 There is no `20` here: a defective floor is this verb's **answer**, not its refusal. `25` is the one
 refusal that outranks the answer, and its position is the point: a plan that is both unapproved and
@@ -720,19 +718,17 @@ comparable to `plan check`'s directly, and a verdict posted afterwards binds the
 
 | Code | Trigger |
 |---|---|
-| `4` | the ledger grammar refused during the re-gate | ✓ |
-| `7` | zero scope — the epic is proven absent or closed, or it has zero children | ✓ |
-| `8` | a write was attempted and no re-read could prove its outcome — UNKNOWN | ✓ |
-| `10` | the issue is not a `type:epic`, or `--digest` is not 12 lowercase hex | ✓ |
-| `11` | a read the flip depends on failed — **nothing is written** | ✓ |
-| `15` | proven: this lane does not hold the epic's claim | ✓ |
-| `20` | proven: the re-gate derived hard defects — the floor is not clean, nothing is written | — |
-| `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check | — |
-| `22` | proven: at least one child is `unchanged`, or the epic did not reach `ready-for:agent` — the refs are on stderr | — |
-| `23` | proven: a label this run would post — `status:triaged`, `status:planned` or `ready-for:agent` — is absent from the repository's labels | — |
-| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — the re-gate covers the human decision too, so a `plan check` that passed before a re-plan cannot be carried past this write | — |
-| `26` | proven: the epic body's `## Dependencies` region has no single meaning — it carries more than one heading, or its only one resolves inside the preserved brief envelope | — | — | — | — | — | — | ✓ |
-| `27` | proven: every issue the topology names closed without landing, so restaging would leave no phase at all — re-plan the epic instead | — | — | — | — | — | — | ✓ |
+| `4` | the ledger grammar refused during the re-gate |
+| `7` | zero scope — the epic is proven absent or closed, or it has zero children |
+| `8` | a write was attempted and no re-read could prove its outcome — UNKNOWN |
+| `10` | the issue is not a `type:epic`, or `--digest` is not 12 lowercase hex |
+| `11` | a read the flip depends on failed — **nothing is written** |
+| `15` | proven: this lane does not hold the epic's claim |
+| `20` | proven: the re-gate derived hard defects — the floor is not clean, nothing is written |
+| `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check |
+| `22` | proven: at least one child is `unchanged`, or the epic did not reach `ready-for:agent` — the refs are on stderr |
+| `23` | proven: a label this run would post — `status:triaged`, `status:planned` or `ready-for:agent` — is absent from the repository's labels |
+| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — the re-gate covers the human decision too, so a `plan check` that passed before a re-plan cannot be carried past this write |
 
 **Errors**
 
@@ -847,19 +843,17 @@ the only emit path; a hand-posted marker is how v1's corpus carried a fake-looki
 
 | Code | Trigger |
 |---|---|
-| `4` | the ledger grammar refused while deriving the floor | ✓ |
-| `5` | the authored caveat text carries a machine-local path | — |
-| `6` | the authored caveat text is a bare `@` path reference | — |
-| `7` | zero scope — the epic is proven absent or closed, or it has zero children | ✓ |
-| `8` | the comment was posted and no re-read could prove it — UNKNOWN | ✓ |
-| `9` | the comment posted but the read-back does not match | ✓ |
-| `10` | `--digest` malformed; the issue is not a `type:epic`; `--polarity` disagrees with the derived floor; a caveat kind off the closed set; a caveat naming a ref outside the scanned set | ✓ |
-| `11` | a read the verdict depends on failed — nothing is posted | ✓ |
-| `15` | proven: this lane does not hold the epic's claim | ✓ |
-| `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check | — |
-| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — nothing is posted | — |
-| `26` | proven: the epic body's `## Dependencies` region has no single meaning — it carries more than one heading, or its only one resolves inside the preserved brief envelope | — | — | — | — | — | — | ✓ |
-| `27` | proven: every issue the topology names closed without landing, so restaging would leave no phase at all — re-plan the epic instead | — | — | — | — | — | — | ✓ |
+| `4` | the ledger grammar refused while deriving the floor |
+| `5` | the authored caveat text carries a machine-local path |
+| `6` | the authored caveat text is a bare `@` path reference |
+| `7` | zero scope — the epic is proven absent or closed, or it has zero children |
+| `8` | the comment was posted and no re-read could prove it — UNKNOWN |
+| `9` | the comment posted but the read-back does not match |
+| `10` | `--digest` malformed; the issue is not a `type:epic`; `--polarity` disagrees with the derived floor; a caveat kind off the closed set; a caveat naming a ref outside the scanned set |
+| `11` | a read the verdict depends on failed — nothing is posted |
+| `15` | proven: this lane does not hold the epic's claim |
+| `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check |
+| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — nothing is posted |
 
 There is no `20` here. A defective floor is not a refusal for this verb — it posts the `FAIL`
 verdict, which is the deliverable. `25` is not that shape: an unapproved plan gets no verdict at all,

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -110,6 +110,7 @@ as the sibling contracts do):
 | `plan flip` | flip every `status:planned` child to `status:triaged` and the epic itself to `ready-for:agent`, re-gating first, reporting the **observed** result for each | a guarded batch write with a read-back — no judgment; *what a partial flip means* stays in the skill |
 | `plan verdict` | post the gate's verdict comment, bound to the scope digest, and read it back | marker composition + a guarded write; the caveats are the skill's judgment, taken as input |
 | `plan approve` | post the approval marker on the epic, bound to a scope digest the verb derives itself, and read it back | an ACL-checked guarded write with a read-back — no judgment; **no `--digest` flag exists**, because an approval whose scope its caller supplies attests whatever the caller pleased |
+| `plan restage` | reconcile an already-minted epic's machine-owned `## Dependencies` region against its children's observed close state, dropping every ref the board proves closed without landing | a filter with a read-back — no judgment; *whether the reconciled plan is still worth building* stays in the skill, and the drop rule is `lane emit`'s own boot rule read backwards |
 | `plan approval` | report the epic's approval state — `current` / `stale` / `absent`, with the marker's author and both digests, honouring only a marker whose author the control-plane roster resolves **at read time** | a total read that never refuses on a missing approval; the enforcement lives in the three verbs that re-derive the floor, never in this report |
 
 **The author gate is in the read, not only in `plan approve`'s write.** Posting a `plan-approved:`
@@ -356,28 +357,30 @@ produced it: [SKILL.md](SKILL.md) step 1 is total (`any other non-zero ends STOP
 on `20`/`21` only off `plan flip` / `plan verdict`. Re-seating at `24`+ would also buy nothing,
 since `epic` already seats `20`–`24` over the same two `build` codes.
 
-| Code | Meaning | `read` | `check` | `flip` | `verdict` | `approve` | `approval` |
-|---|---|---|---|---|---|---|---|
-| `0` | the answer is on stdout | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `1` | usage error, or the verb failed to run | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `126` | no implementation could be resolved (`src/bin.ts`) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `3` | stdin was read and held nothing | — | — | — | — | — | — |
-| `4` | a required section is unparseable, duplicated, or mis-numbered in a document the verb derives from | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `5` | the **authored** text carries a machine-local path | — | — | — | ✓ | — | — |
-| `6` | the authored text is a bare `@` path reference — not redactable | — | — | — | ✓ | — | — |
-| `7` | zero scope: the epic is proven absent (404) or closed, or it has zero children | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `8` | a write was attempted and its outcome could not be proven — UNKNOWN | — | — | ✓ | ✓ | ✓ | — |
-| `9` | the write landed but the read-back does not match | — | — | — | ✓ | ✓ | — |
-| `10` | a value off its closed vocabulary — a semantic refusal, never a malformed-flag usage error | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `11` | a required read failed — nothing was written, no outcome is proven | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `15` | proven: this lane does not hold the epic's claim (imported from `build`) | — | — | ✓ | ✓ | — | — |
-| `20` | proven: the floor derived hard defects — refused as a **precondition to writing**, never as `plan check`'s own answer | — | — | ✓ | — | — | — |
-| `21` | proven: the plan moved — the recomputed digest differs from the `--digest` the caller carried | — | — | ✓ | ✓ | — | — |
-| `22` | proven: at least one child is `unchanged` — the flip did not fully apply; the observed set is on stderr | — | — | ✓ | — | — | — |
-| `23` | proven: a label the flip must write is absent from the repository's taxonomy | — | — | ✓ | — | — | — |
-| `24` | proven: the invoking account may not approve this epic's plan — it is outside the control-plane roster resolved from CODEOWNERS at write time, or that roster names nobody | — | — | — | — | ✓ | — |
-| `25` | proven: the plan is not approved as it now stands — the epic carries no standing approval marker, or the marker's digest names a plan the epic has since moved off | — | ✓ | ✓ | ✓ | — | — |
-| `127` | the verb never ran (unresolved binary) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Code | Meaning | `read` | `check` | `flip` | `verdict` | `approve` | `approval` | `restage` |
+|---|---|---|---|---|---|---|---|---|
+| `0` | the answer is on stdout | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `1` | usage error, or the verb failed to run | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `126` | no implementation could be resolved (`src/bin.ts`) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `3` | stdin was read and held nothing | — | — | — | — | — | — | — |
+| `4` | a required section is unparseable, duplicated, or mis-numbered in a document the verb derives from | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `5` | the **authored** text carries a machine-local path | — | — | — | ✓ | — | — | — |
+| `6` | the authored text is a bare `@` path reference — not redactable | — | — | — | ✓ | — | — | — |
+| `7` | zero scope: the epic is proven absent (404) or closed, or it has zero children | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `8` | a write was attempted and its outcome could not be proven — UNKNOWN | — | — | ✓ | ✓ | ✓ | — | ✓ |
+| `9` | the write landed but the read-back does not match | — | — | — | ✓ | ✓ | — | ✓ |
+| `10` | a value off its closed vocabulary — a semantic refusal, never a malformed-flag usage error | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `11` | a required read failed — nothing was written, no outcome is proven | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `15` | proven: this lane does not hold the epic's claim (imported from `build`) | — | — | ✓ | ✓ | — | — | ✓ |
+| `20` | proven: the floor derived hard defects — refused as a **precondition to writing**, never as `plan check`'s own answer | — | — | ✓ | — | — | — | — |
+| `21` | proven: the plan moved — the recomputed digest differs from the `--digest` the caller carried | — | — | ✓ | ✓ | — | — | — |
+| `22` | proven: at least one child is `unchanged` — the flip did not fully apply; the observed set is on stderr | — | — | ✓ | — | — | — | — |
+| `23` | proven: a label the flip must write is absent from the repository's taxonomy | — | — | ✓ | — | — | — | — |
+| `24` | proven: the invoking account may not approve this epic's plan — it is outside the control-plane roster resolved from CODEOWNERS at write time, or that roster names nobody | — | — | — | — | ✓ | — | — |
+| `25` | proven: the plan is not approved as it now stands — the epic carries no standing approval marker, or the marker's digest names a plan the epic has since moved off | — | ✓ | ✓ | ✓ | — | — | — |
+| `26` | proven: the epic body's `## Dependencies` region has no single meaning — it carries more than one heading, or its only one resolves inside the preserved brief envelope | — | — | — | — | — | — | ✓ |
+| `27` | proven: every issue the topology names closed without landing, so restaging would leave no phase at all — re-plan the epic instead | — | — | — | — | — | — | ✓ |
+| `127` | the verb never ran (unresolved binary) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 `3` is a seat no `plan` verb reaches: the only stdin-taking verb is `plan verdict`, whose stdin is
 **optional** (a clean verdict with no caveats is an ordinary answer), so an empty stdin is a fact,
@@ -443,10 +446,10 @@ absent or non-conforming. `topology` is the imported `readTopology` parse. `cycl
 
 | Code | Trigger |
 |---|---|
-| `4` | the epic body's `## Dependencies` is `Unparseable`; a ledger section appears more than once; a child's `**Stories:**` or `**Containment:**` field line appears more than once; or a **non-empty** `### User stories` list is not contiguous from 1 |
-| `7` | the epic is proven absent (404) or closed, or it has zero sub-issue children |
-| `10` | the issue is not a `type:epic` |
-| `11` | the epic, the sub-issue list, or a child could not be read (when this was written this row also named the `product-development-cycle.md` probe, so the premise is stale and the conclusion is not — the probe is total and answers `unknown` on a failed read, which the output schema above carries and `plan check` names in `skipped`; `11` stays reachable by the three reads named here) |
+| `4` | the epic body's `## Dependencies` is `Unparseable`; a ledger section appears more than once; a child's `**Stories:**` or `**Containment:**` field line appears more than once; or a **non-empty** `### User stories` list is not contiguous from 1 | ✓ |
+| `7` | the epic is proven absent (404) or closed, or it has zero sub-issue children | ✓ |
+| `10` | the issue is not a `type:epic` | ✓ |
+| `11` | the epic, the sub-issue list, or a child could not be read (when this was written this row also named the `product-development-cycle.md` probe, so the premise is stale and the conclusion is not — the probe is total and answers `unknown` on a failed read, which the output schema above carries and `plan check` names in `skipped`; `11` stays reachable by the three reads named here) | ✓ |
 
 An **absent** `## Dependencies` block is *not* `4` — it is defect `MISSING_DEPS_SECTION`, which
 `plan check` derives. `4` is the unparseable, duplicated and mis-numbered cases only.
@@ -542,11 +545,13 @@ trusted a caller-supplied ledger would grade a document the caller could edit.
 
 | Code | Trigger |
 |---|---|
-| `4` | the ledger grammar refused, exactly as `plan read` |
-| `7` | zero scope — the epic is proven absent or closed, or it has zero children |
-| `10` | the issue is not a `type:epic` |
-| `11` | any read the floor depends on failed — nothing is graded, and no verdict is implied; the control-plane roster is one such read, so an unreadable roster is `11` and never `25` |
-| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — refused **before** the floor is derived |
+| `4` | the ledger grammar refused, exactly as `plan read` | ✓ |
+| `7` | zero scope — the epic is proven absent or closed, or it has zero children | ✓ |
+| `10` | the issue is not a `type:epic` | ✓ |
+| `11` | any read the floor depends on failed — nothing is graded, and no verdict is implied; the control-plane roster is one such read, so an unreadable roster is `11` and never `25` | ✓ |
+| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — refused **before** the floor is derived | — |
+| `26` | proven: the epic body's `## Dependencies` region has no single meaning — it carries more than one heading, or its only one resolves inside the preserved brief envelope | — | — | — | — | — | — | ✓ |
+| `27` | proven: every issue the topology names closed without landing, so restaging would leave no phase at all — re-plan the epic instead | — | — | — | — | — | — | ✓ |
 
 There is no `20` here: a defective floor is this verb's **answer**, not its refusal. `25` is the one
 refusal that outranks the answer, and its position is the point: a plan that is both unapproved and
@@ -715,17 +720,19 @@ comparable to `plan check`'s directly, and a verdict posted afterwards binds the
 
 | Code | Trigger |
 |---|---|
-| `4` | the ledger grammar refused during the re-gate |
-| `7` | zero scope — the epic is proven absent or closed, or it has zero children |
-| `8` | a write was attempted and no re-read could prove its outcome — UNKNOWN |
-| `10` | the issue is not a `type:epic`, or `--digest` is not 12 lowercase hex |
-| `11` | a read the flip depends on failed — **nothing is written** |
-| `15` | proven: this lane does not hold the epic's claim |
-| `20` | proven: the re-gate derived hard defects — the floor is not clean, nothing is written |
-| `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check |
-| `22` | proven: at least one child is `unchanged`, or the epic did not reach `ready-for:agent` — the refs are on stderr |
-| `23` | proven: a label this run would post — `status:triaged`, `status:planned` or `ready-for:agent` — is absent from the repository's labels |
-| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — the re-gate covers the human decision too, so a `plan check` that passed before a re-plan cannot be carried past this write |
+| `4` | the ledger grammar refused during the re-gate | ✓ |
+| `7` | zero scope — the epic is proven absent or closed, or it has zero children | ✓ |
+| `8` | a write was attempted and no re-read could prove its outcome — UNKNOWN | ✓ |
+| `10` | the issue is not a `type:epic`, or `--digest` is not 12 lowercase hex | ✓ |
+| `11` | a read the flip depends on failed — **nothing is written** | ✓ |
+| `15` | proven: this lane does not hold the epic's claim | ✓ |
+| `20` | proven: the re-gate derived hard defects — the floor is not clean, nothing is written | — |
+| `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check | — |
+| `22` | proven: at least one child is `unchanged`, or the epic did not reach `ready-for:agent` — the refs are on stderr | — |
+| `23` | proven: a label this run would post — `status:triaged`, `status:planned` or `ready-for:agent` — is absent from the repository's labels | — |
+| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — the re-gate covers the human decision too, so a `plan check` that passed before a re-plan cannot be carried past this write | — |
+| `26` | proven: the epic body's `## Dependencies` region has no single meaning — it carries more than one heading, or its only one resolves inside the preserved brief envelope | — | — | — | — | — | — | ✓ |
+| `27` | proven: every issue the topology names closed without landing, so restaging would leave no phase at all — re-plan the epic instead | — | — | — | — | — | — | ✓ |
 
 **Errors**
 
@@ -840,17 +847,19 @@ the only emit path; a hand-posted marker is how v1's corpus carried a fake-looki
 
 | Code | Trigger |
 |---|---|
-| `4` | the ledger grammar refused while deriving the floor |
-| `5` | the authored caveat text carries a machine-local path |
-| `6` | the authored caveat text is a bare `@` path reference |
-| `7` | zero scope — the epic is proven absent or closed, or it has zero children |
-| `8` | the comment was posted and no re-read could prove it — UNKNOWN |
-| `9` | the comment posted but the read-back does not match |
-| `10` | `--digest` malformed; the issue is not a `type:epic`; `--polarity` disagrees with the derived floor; a caveat kind off the closed set; a caveat naming a ref outside the scanned set |
-| `11` | a read the verdict depends on failed — nothing is posted |
-| `15` | proven: this lane does not hold the epic's claim |
-| `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check |
-| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — nothing is posted |
+| `4` | the ledger grammar refused while deriving the floor | ✓ |
+| `5` | the authored caveat text carries a machine-local path | — |
+| `6` | the authored caveat text is a bare `@` path reference | — |
+| `7` | zero scope — the epic is proven absent or closed, or it has zero children | ✓ |
+| `8` | the comment was posted and no re-read could prove it — UNKNOWN | ✓ |
+| `9` | the comment posted but the read-back does not match | ✓ |
+| `10` | `--digest` malformed; the issue is not a `type:epic`; `--polarity` disagrees with the derived floor; a caveat kind off the closed set; a caveat naming a ref outside the scanned set | ✓ |
+| `11` | a read the verdict depends on failed — nothing is posted | ✓ |
+| `15` | proven: this lane does not hold the epic's claim | ✓ |
+| `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check | — |
+| `25` | proven: the epic carries no standing approval, or the standing one binds a digest the plan has moved off — nothing is posted | — |
+| `26` | proven: the epic body's `## Dependencies` region has no single meaning — it carries more than one heading, or its only one resolves inside the preserved brief envelope | — | — | — | — | — | — | ✓ |
+| `27` | proven: every issue the topology names closed without landing, so restaging would leave no phase at all — re-plan the epic instead | — | — | — | — | — | — | ✓ |
 
 There is no `20` here. A defective floor is not a refusal for this verb — it posts the `FAIL`
 verdict, which is the deliverable. `25` is not that shape: an unapproved plan gets no verdict at all,
@@ -916,6 +925,99 @@ $ echo $?
 
 ---
 
+## `plan restage`
+
+**Invocation**
+
+```
+fabrika plan restage 3 --token <claim-token>
+```
+
+| Flag | Type | Default | Meaning |
+|---|---|---|---|
+| `<number>` | integer, positional | — | the epic whose `## Dependencies` region is reconciled |
+| `--token` | string | — | the claim token `build claim <epic> --purpose gate` handed this lane |
+| `--repo` | string | `$CLAUDE_PIPELINE_REPO`, else `$GITHUB_REPOSITORY`, else the origin remote | the target `owner/name` |
+
+**What it decides, and the one rule it decides on**
+
+It is not part of the gate's own sequence: it is the repair a *post-mint* child close leaves behind.
+`lane emit` builds one machine region per child the region names and boots that region from the
+child's close reason — `completed` boots `landed`, and **every other close boots `frozen`**, a final
+carrying a door, so the phase trips the instant the machine starts (`src/lane/emit.ts`, `initialFor`).
+An epic that lost a child to a duplicate close could therefore only ever emit a machine that dies,
+and the sole repair was a human editing the epic body by hand.
+
+So the rule is `lane emit`'s boot rule read backwards: **a ref the board proves closed for any reason
+other than `completed` is dropped, and nothing else is.** A `completed` close is kept — its region
+boots `landed`, the phase folds, and dropping it would erase the sequencing the children planned
+behind it depend on. A phase line that loses every member disappears, and so does a `requires:` line
+whose subject was dropped or whose needs all were.
+
+**Scope: the epic's native sub-issue links, and nothing wider.** That is the same set `lane emit`
+checks every ref against, so the two can never disagree about one edge. A ref the link list does not
+name — a cross-epic prerequisite, a ledger-local `C<int>` — is **unobserved, not abandoned**: it is
+round-tripped exactly as written, and `lane emit`'s own `Foreign` arm is what reports it. A reconcile
+that dropped an unobserved ref would be rewriting a plan on no evidence.
+
+**Zero scope.** Zero sub-issue children is `7`, as it is for every verb in the group. A body with no
+`## Dependencies` heading at all is `7` too — there is no region to reconcile and the epic needs
+planning, not restaging. A body carrying *two* headings, or one heading resolving inside the
+preserved brief envelope, is `26` instead: those are bytes that look like a region with no way to
+tell which are the plan, and rewriting on that guess is how a body gets destroyed.
+
+**Idempotence is decided on the refs, never on the bytes.** A region naming only live issues answers
+`unchanged` and issues no PATCH at all, so a re-run neither reformats the block nor moves the body
+digest a standing approval binds. Only a run that actually drops something composes a body, and that
+body is proven by re-reading the whole issue and comparing it normalized — the same discipline
+`ledger write` runs, for the same reason.
+
+**Stdout**
+
+```
+$ fabrika plan restage 3 --token <claim-token>
+{"answer":"restaged","epic":3,"dropped":[42,43],"kept":[41,44],"written":true,"verified":true}
+```
+
+```
+$ fabrika plan restage 3 --token <claim-token>
+{"answer":"unchanged","epic":3,"dropped":[],"kept":[41,44],"written":false}
+```
+
+```
+$ fabrika plan restage 3 --token <claim-token>
+plan restage: every issue #3's topology names closed without landing (#<a>, #<b>) — restaging would leave no phase at all, so re-plan the epic instead. Nothing was written.
+$ echo $?
+27
+```
+
+`#<a>, #<b>` stands for the dropped children's own numbers, ascending — every one of them, never a
+cap-and-count, because the whole list is what says the plan is gone rather than thinned.
+
+**Errors**
+
+| Code | Trigger |
+|---|---|
+| `4` | the `## Dependencies` block is unparseable — the defective line is named; nothing was written |
+| `7` | the epic is proven absent or closed, it has zero sub-issue children, or its body carries no `## Dependencies` region at all |
+| `8` | the PATCH was issued and could not be confirmed — the body is UNKNOWN |
+| `9` | the body was written and does not read back as composed, or the composed region does not parse back to the edges it was composed from |
+| `10` | the issue is not a `type:epic`, or the number is not a positive integer |
+| `11` | the epic or its sub-issue list could not be read — nothing was written |
+| `15` | this lane does not hold the epic's claim — `--token` says which lane is asking |
+| `26` | the body carries more than one `## Dependencies` heading, or its only one resolves inside the preserved brief envelope |
+| `27` | every issue the topology names closed without landing — restaging would leave no phase at all |
+
+**Grounding**
+
+- `src/lane/emit.ts`'s `initialFor` is where the drop rule comes from; this verb states no second
+  opinion about what a close means.
+- `src/build/dependencies.ts` owns where the section ends, and both the reader and this writer take
+  the span from it — two scans is two answers about which bytes are safe to overwrite.
+- The composed region is parsed back through the shipped reader before anything is written, which is
+  `ledger topology`'s round-trip discipline applied to an edit rather than to a fresh render.
+- The preserved-brief bound is `triage enrich`'s marker; `ledger write` refuses on the same bound,
+  because v1 cutting there destroyed an epic body.
 
 ---
 
@@ -944,7 +1046,10 @@ The three hand-checks, which the presence tests above cannot perform:
    `terminal` from their closed sets; the marker line from `emit`'s template plus the fixed clause
    grammar; `containment`, `stories` and the edge orientation from §The ledger grammar. `comment`
    is server-assigned and named as such.
-3. **Sibling verbs guard shared preconditions identically.** All four run `resolveTargetRepo`, the
-   `type:epic` check (`10`) and the same `7` trigger; both mutating verbs run the imported
-   `requireClaim` and take `--digest` with the same `21` refusal; `flip` states its one documented
-   divergence — zero *planned* children is an answer, not a refusal — with its reason.
+3. **Sibling verbs guard shared preconditions identically.** Every verb runs `resolveTargetRepo`,
+   the `type:epic` check (`10`) and the same `7` trigger; every claim-gated verb runs the imported
+   `requireClaim`, and the two digest-gated ones take `--digest` with the same `21` refusal. Two
+   verbs state a documented divergence with its reason: `flip`'s zero *planned* children is an
+   answer rather than a refusal, and `restage` widens `7` to cover a body carrying no
+   `## Dependencies` region at all — a plan that does not exist and a scope that is empty are the
+   same fact about an epic nobody can build from.

--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -775,11 +775,17 @@ Gate an epic's plan before its children build — the read-and-verdict half of e
 | `plan check` | the deterministic floor over the fifteen hard defect types |
 | `plan flip` | every planned child flipped to triaged, re-gated first |
 | `plan verdict` | the plan gate's verdict, posted bound to the scope digest |
+| `plan approve` | a control-plane approval of the epic's plan, recorded |
+| `plan approval` | the epic's approval state — current, stale or absent |
+| `plan restage` | a minted epic's `## Dependencies` region, reconciled against its children's close state |
 
 **Exit codes.** The shared table, plus `15` this session does not hold the claim · `20` the floor
 found a hard defect · `21` the recomputed scope digest differs from the `--digest` the caller
 carried · `22` at least one child is `unchanged` — the flip did not fully apply · `23` a label the
-flip must write is absent from the repository's taxonomy.
+flip must write is absent from the repository's taxonomy · `24` the invoking account may not approve
+this epic's plan · `25` the plan is not approved as it now stands · `26` the `## Dependencies` region
+has no single meaning — two headings, or the only one inside the preserved brief · `27` restaging
+would leave the topology with no phase at all.
 
 ## The `recipe` group
 

--- a/packages/fabrika-cli/src/build/dependencies.ts
+++ b/packages/fabrika-cli/src/build/dependencies.ts
@@ -98,18 +98,57 @@ const parseRefList = (raw: string): ReadonlyArray<Ref> | null => {
 	return refs;
 };
 
+/**
+ * The `[heading, end)` line span of one `## Dependencies` section, 0-based, `end` exclusive.
+ *
+ * A reader that only wants the edges takes {@link readTopology}; a *writer* needs the bytes it may
+ * replace, and deriving those from a second scan is how two modules come to disagree about where the
+ * section ends. `plan restage` splices over this span.
+ */
+export interface TopologySpan {
+	readonly heading: number;
+	readonly end: number;
+}
+
+/**
+ * Every `## Dependencies` section in the body, in body order.
+ *
+ * All of them rather than the first, because *how many there are* is itself an answer: `readTopology`
+ * reads the first because a reader must pick one, while a writer refuses a body carrying two — a
+ * section with no single meaning is not a section to rewrite. A second heading terminates the first
+ * span, so the spans never overlap.
+ */
+export const topologySpans = (body: string): ReadonlyArray<TopologySpan> => {
+	const lines = body.split("\n");
+	const spans: TopologySpan[] = [];
+	for (let heading = 0; heading < lines.length; heading++) {
+		if (!HEADING_RE.test((lines[heading] ?? "").trim())) continue;
+		let end = lines.length;
+		for (let i = heading + 1; i < lines.length; i++) {
+			const raw = lines[i] ?? "";
+			const text = raw.trim();
+			if (text === "") continue;
+			if (ANY_HEADING_RE.test(text) || isThematicBreak(raw)) {
+				end = i;
+				break;
+			}
+		}
+		spans.push({heading, end});
+	}
+	return spans;
+};
+
 /** Read a body's `## Dependencies` block. */
 export const readTopology = (body: string): Topology => {
 	const lines = body.split("\n");
-	const start = lines.findIndex((line) => HEADING_RE.test(line.trim()));
-	if (start === -1) return {_tag: "Absent"};
+	const span = topologySpans(body)[0];
+	if (span === undefined) return {_tag: "Absent"};
 
 	const edges: Edge[] = [];
-	for (let i = start + 1; i < lines.length; i++) {
+	for (let i = span.heading + 1; i < span.end; i++) {
 		const raw = lines[i] ?? "";
 		const text = raw.trim();
 		if (text === "") continue;
-		if (ANY_HEADING_RE.test(text) || isThematicBreak(raw)) break;
 
 		const phase = PHASE_RE.exec(text);
 		if (phase?.[1] !== undefined && phase[2] !== undefined) {
@@ -137,6 +176,25 @@ export const sameRef = (a: Ref, b: Ref): boolean =>
 		: a._tag === "Local" && b._tag === "Local" && a.id === b.id;
 
 export const renderRef = (ref: Ref): string => (ref._tag === "Issue" ? `#${ref.number}` : ref.id);
+
+/**
+ * A parsed edge list back as a `## Dependencies` section, heading included, one line per edge in the
+ * order given.
+ *
+ * The inverse of {@link readTopology} over the shape {@link readTopology} produces, which is what
+ * `ledger/topology-doc.ts`'s `renderDependencies` is *not*: that one composes a block out of declared
+ * `#<n> phase <k>` lines, so it can express neither a ledger-local `C<int>` ref nor a `requires:`
+ * subject sitting in no phase. A verb that edits an existing block has to round-trip whatever the
+ * planner wrote, including both.
+ */
+export const renderTopologyBlock = (edges: ReadonlyArray<Edge>): string => {
+	const rows = edges.map((edge) =>
+		edge._tag === "Phase"
+			? `- phase ${edge.phase}: ${edge.members.map(renderRef).join(", ")}`
+			: `- ${renderRef(edge.subject)} requires: ${edge.needs.map(renderRef).join(", ")}`,
+	);
+	return `## Dependencies\n\n${rows.join("\n")}\n`;
+};
 
 /**
  * Every predecessor of `subject`, with the kind of edge that names it.

--- a/packages/fabrika-cli/src/ledger/region.ts
+++ b/packages/fabrika-cli/src/ledger/region.ts
@@ -14,7 +14,7 @@
  */
 
 import {unfencedLines} from "../plan/ledger.ts";
-import {MARKER_RE} from "../triage/enrich.ts";
+import {preservedEnvelope} from "../triage/enrich.ts";
 import {PLAN_HEADING} from "./plan-block.ts";
 import type {PlanMode} from "./run.ts";
 
@@ -38,16 +38,6 @@ const unresolvable = (reason: string): Splice => ({_tag: "Unresolvable", reason}
 
 const headingCount = (epic: number, heading: string, count: number): string =>
 	`#${epic}'s body carries ${count} "${heading}" headings — the plan region has no single meaning.`;
-
-/** The `[start, end)` line span of the preserved brief envelope, or `null` when there is no marker. */
-const envelopeOf = (lines: ReadonlyArray<string>): {start: number; end: number} | null => {
-	const start = lines.findIndex((line) => MARKER_RE.test(line.trim()));
-	if (start === -1) return null;
-	const closing = lines.findIndex(
-		(line, index) => index > start && line.trim().toLowerCase() === "</details>",
-	);
-	return {start, end: closing === -1 ? start : closing};
-};
 
 export interface SpliceInput {
 	readonly epic: number;
@@ -96,7 +86,7 @@ export const splicePlan = (input: SpliceInput): Splice => {
 
 	const start = planAnchors[0] as number;
 	const dependencies = dependencyAnchors[0] as number;
-	const envelope = envelopeOf(lines);
+	const envelope = preservedEnvelope(lines);
 	if (envelope !== null && dependencies > envelope.start && dependencies < envelope.end) {
 		return unresolvable(
 			`#${input.epic}'s "${DEPENDENCIES_HEADING}" heading resolves inside the preserved brief envelope — refusing to cut the region there.`,

--- a/packages/fabrika-cli/src/plan/codes.ts
+++ b/packages/fabrika-cli/src/plan/codes.ts
@@ -1,5 +1,5 @@
 /**
- * The one exit table the four `plan` verbs allocate from.
+ * The one exit table the `plan` verbs allocate from.
  *
  * Three tiers, and the tier decides how a constant gets here rather than what it means:
  *
@@ -10,7 +10,7 @@
  *   verb reaches it, because an omitted seat reads to the checker as drift.
  * - `15` is `build`'s, **imported verbatim**. This group holds a `build` claim, so a caller driving
  *   both in one sweep must read one meaning for it.
- * - `20`–`23` are this group's own.
+ * - `20`–`27` are this group's own.
  *
  * **Why `20`/`21` overlapping `build`'s `OUT_OF_SCOPE`/`AUDIENCE_NOT_AGENT` is safe.** The
  * contract seated these when `20`+ was free; the scope-admission fence has since taken both, and both
@@ -79,3 +79,21 @@ export const APPROVAL_UNAUTHORIZED = 24;
  * round, which no `plan` verb produces.
  */
 export const PLAN_UNAPPROVED = 25;
+/**
+ * Proven: the epic body carries a `## Dependencies` heading that is not a machine-owned region —
+ * more than one of them, or one sitting inside the preserved brief envelope.
+ *
+ * Its own seat rather than {@link ZERO_SCOPE}, because the two are opposite facts about a body: `7`
+ * says there is no region to reconcile and the epic needs planning, this says there are bytes that
+ * *look* like one and no way to tell which are the plan. Rewriting on a guess is how a body gets
+ * destroyed, so the guess is refused instead.
+ */
+export const REGION_UNRESOLVABLE = 26;
+/**
+ * Proven: every issue the topology names closed without landing, so reconciling would leave no phase.
+ *
+ * Not an answer and not {@link REGION_UNRESOLVABLE} — the region parsed and its meaning was single.
+ * The epic simply has no plan left, which a re-plan fixes and a rewrite cannot: writing the empty
+ * block would erase the record of what was planned while leaving the epic just as unbuildable.
+ */
+export const TOPOLOGY_EMPTIED = 27;

--- a/packages/fabrika-cli/src/plan/command.ts
+++ b/packages/fabrika-cli/src/plan/command.ts
@@ -23,6 +23,7 @@ import {runApprove} from "./approve-verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runFlip} from "./flip-verb.ts";
 import {runRead} from "./read-verb.ts";
+import {runRestage} from "./restage-verb.ts";
 import {runVerdict} from "./verdict-verb.ts";
 
 const repoFlag = Flag.string("repo").pipe(
@@ -176,6 +177,21 @@ const approval = leafCommand(
 	),
 );
 
+const restage = leafCommand(
+	"restage",
+	{number: epicArg, token: tokenFlag, repo: repoFlag},
+	Effect.fn(function* ({number, token, repo}) {
+		yield* emit(yield* runRestage({number, token, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription(
+		"Reconcile a minted epic's Dependencies region against its children.",
+	),
+	Command.withDescription(
+		'Reconcile an already-planned epic\'s machine-owned "## Dependencies" region against the observed state of its native sub-issue links, so a post-mint child close no longer needs a hand edit to the epic body. One rule: a ref the links prove closed for any reason other than `completed` is dropped, because `lane emit` boots exactly those in `frozen` and trips the phase at startup; a `completed` close is KEPT, since its region boots `landed` and the children planned behind it still need the sequencing. A phase line that loses every member disappears, and so does a `requires:` line whose subject was dropped or whose needs all were. A ref the link list does not name — a cross-epic prerequisite, a ledger-local C<int> — is left exactly as written, because it is not observed here; `lane emit`\'s own Foreign arm is what reports it. Nothing outside the region is touched, and it is idempotent by REFS rather than by bytes: a region naming only live issues prints {"answer":"unchanged","epic":n,"dropped":[],"kept":[…],"written":false} and issues no PATCH, so a re-run neither reformats the block nor moves the body digest a standing approval binds. A write prints {"answer":"restaged","epic":n,"dropped":[…],"kept":[…],"written":true,"verified":true} after the whole body reads back as composed. Exits 4 (the ## Dependencies block is unparseable — nothing written), 7 (the epic is proven absent or closed, it has zero sub-issue children, or its body carries no ## Dependencies region at all — plan it first), 8 (the PATCH was issued and could not be confirmed — the body is UNKNOWN), 9 (the body was written and does not read back as composed, or the composed region does not parse back to the edges it was composed from), 10 (the issue is not a type:epic), 11 (the epic or its sub-issue list could not be read — nothing written), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking), 26 (the body carries more than one "## Dependencies" heading, or its only one sits inside the preserved brief envelope — the region has no single meaning and nothing was written), 27 (every issue the topology names closed without landing, so restaging would leave no phase — re-plan the epic instead). Example: fabrika plan restage 9420 --token build:s-9f2e:c1a4d6f8-…',
+	),
+);
+
 export const planCommand = Command.make("plan").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
@@ -185,6 +201,7 @@ export const planCommand = Command.make("plan").pipe(
 		verdict,
 		approve,
 		approval,
+		restage,
 	]),
 	Command.withShortDescription("Gate an epic's plan before its children build."),
 	Command.withDescription(

--- a/packages/fabrika-cli/src/plan/restage-verb.ts
+++ b/packages/fabrika-cli/src/plan/restage-verb.ts
@@ -1,0 +1,197 @@
+/**
+ * `plan restage` — reconcile an already-minted epic's `## Dependencies` region against its children's
+ * observed close state, byte-verified.
+ *
+ * The gap it closes: nothing in `plan` or `lane` could re-stage a topology after a child was closed.
+ * `lane emit` builds one machine region per child the region names and boots a non-`completed` close
+ * in `frozen`, which trips the phase the moment the machine starts — so an epic that lost a child to
+ * a duplicate close could only emit a machine that dies, and the sole repair was a human editing the
+ * epic body. This verb is that repair, and it is the whole of it: it drops abandoned refs and does
+ * nothing else. It adds no child, re-phases nothing, and touches no byte outside the region.
+ *
+ * **The observations are the epic's native sub-issue links**, which is the same set `lane emit`
+ * checks every ref against, so the two never disagree about one edge. What the links do not name,
+ * this verb does not judge — `restage.ts` states why.
+ *
+ * Idempotence is decided on the *refs*, not the bytes: a region naming only live issues answers
+ * `unchanged` and issues no PATCH at all, so a re-run neither rewrites formatting nor moves the
+ * body digest a standing approval is bound to.
+ */
+
+import {Effect, type FileSystem} from "effect";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {requireCallerToken, requireClaim, requireSession} from "../build/claim.ts";
+import {badNumber, resolveTargetRepo, scannedLine} from "../build/target.ts";
+import {getIssue, patchIssueBody} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BAD_SECTIONS,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	REGION_UNRESOLVABLE,
+	TOPOLOGY_EMPTIED,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {listSubIssues} from "./github.ts";
+import {type PlanMessages, requireEpic, scannedChildren} from "./load.ts";
+import {restageBody} from "./restage.ts";
+
+const VERB = "plan restage";
+
+export const MESSAGES: PlanMessages = {
+	verb: VERB,
+	grammar: (reason) => `${VERB}: ${reason}`,
+	zeroChildren: (epic) =>
+		`${VERB}: #${epic} has zero sub-issue children — there is no topology to reconcile.`,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic — refusing to restage its plan.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — nothing was written.`,
+};
+
+export interface RestageOptions {
+	readonly number: number;
+	/** The claim token `build claim <epic> --purpose gate` handed this lane — which lane is asking. */
+	readonly token: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runRestage = (
+	options: RestageOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | HttpClient.HttpClient
+> =>
+	Effect.gen(function* () {
+		const bad = badNumber(VERB, "an issue number", options.number);
+		if (bad !== null) return bad;
+
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* requireEpic(MESSAGES, repo, options.number);
+		if (target._tag === "Refused") return target.outcome;
+		const epic = target.issue;
+
+		const asking = requireCallerToken(VERB, session.id, options.token);
+		if (asking._tag === "Refused") return asking.outcome;
+
+		const held = yield* requireClaim(VERB, repo, options.number, asking.caller);
+		if (held._tag === "Refused") return held.outcome;
+
+		const links = yield* listSubIssues(repo, epic.number, options.env);
+		if (links._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable(`the sub-issue list of #${epic.number}`, links.reason),
+				held.notes,
+			);
+		}
+		if (links.value.length === 0) {
+			return refuse(ZERO_SCOPE, MESSAGES.zeroChildren(epic.number), held.notes);
+		}
+		const notes = [
+			...held.notes,
+			scannedChildren(
+				VERB,
+				links.value.map((link) => link.number),
+			),
+		];
+
+		const restaged = restageBody(epic.body, links.value);
+		switch (restaged._tag) {
+			case "Absent":
+				return refuse(
+					ZERO_SCOPE,
+					`${VERB}: #${epic.number} carries no \`## Dependencies\` region — plan the epic before restaging it.`,
+					notes,
+				);
+			case "Ambiguous":
+				return refuse(
+					REGION_UNRESOLVABLE,
+					`${VERB}: #${epic.number}'s body carries ${restaged.count} "## Dependencies" headings — the region has no single meaning, and nothing was written.`,
+					notes,
+				);
+			case "InPreservedBrief":
+				return refuse(
+					REGION_UNRESOLVABLE,
+					`${VERB}: #${epic.number}'s only "## Dependencies" heading resolves inside the preserved brief envelope — that is filed content, not a machine-owned region, and nothing was written.`,
+					notes,
+				);
+			case "Unparseable":
+				return refuse(
+					BAD_SECTIONS,
+					`${VERB}: #${epic.number}'s ## Dependencies block is unparseable at line ${restaged.line}: ${restaged.text} — nothing was written.`,
+					notes,
+				);
+			case "Emptied":
+				return refuse(
+					TOPOLOGY_EMPTIED,
+					`${VERB}: every issue #${epic.number}'s topology names closed without landing (${restaged.dropped.map((n) => `#${n}`).join(", ")}) — restaging would leave no phase at all, so re-plan the epic instead. Nothing was written.`,
+					notes,
+				);
+			case "ReadbackMismatch":
+				return refuse(
+					READBACK_MISMATCH,
+					`${VERB}: the reconciled region does not parse back to the edges it was composed from — refusing to write it.`,
+					notes,
+				);
+			case "Unchanged":
+				return answer(
+					JSON.stringify({
+						answer: "unchanged",
+						epic: epic.number,
+						dropped: [],
+						kept: restaged.kept,
+						written: false,
+					}),
+					notes,
+				);
+			case "Restaged":
+				break;
+		}
+
+		const patched = yield* patchIssueBody(repo, epic.number, restaged.body);
+		if (patched._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the PATCH was issued and could not be confirmed — the body is UNKNOWN.`,
+				[...notes, `${VERB}: ${patched.reason}.`],
+			);
+		}
+
+		const reread = yield* getIssue(repo, epic.number);
+		if (reread._tag !== "Present") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the PATCH was issued and could not be confirmed — the body is UNKNOWN.`,
+				notes,
+			);
+		}
+		if (normalizeForReadback(reread.value.body) !== normalizeForReadback(restaged.body)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the body was written and does not read back as composed — it needs a human eye.`,
+				notes,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "restaged",
+				epic: epic.number,
+				dropped: restaged.dropped,
+				kept: restaged.kept,
+				written: true,
+				verified: true,
+			}),
+			[...notes, scannedLine(VERB, 1, "epic body", `dropped ${restaged.dropped.length}`)],
+		);
+	});

--- a/packages/fabrika-cli/src/plan/restage-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/restage-verb.unit.test.ts
@@ -1,0 +1,197 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {comments, LANE_UUID, marker, LANE_TOKEN as TOKEN} from "../build/fixtures.test-support.ts";
+import {type HttpReply, once} from "../fakes.test-support.ts";
+import {
+	BAD_SECTIONS,
+	CLAIM_NOT_MINE,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	REGION_UNRESOLVABLE,
+	TOPOLOGY_EMPTIED,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	epic,
+	epicBody,
+	planSeams,
+	type Scripted,
+	SESSION,
+	SUB_ISSUES,
+} from "./fixtures.test-support.ts";
+import {runRestage} from "./restage-verb.ts";
+
+const EPIC = /^GET https:\/\/api\.github\.com\/repos\/o\/r\/issues\/4300$/;
+const SUBS = SUB_ISSUES;
+const COMMENTS = /^GET .*\/repos\/o\/r\/issues\/4300\/comments\?/;
+const PERM = /^GET .*\/repos\/o\/r\/collaborators\/agent\/permission/;
+const PATCH = /^PATCH .*\/repos\/o\/r\/issues\/4300$/;
+const ANY_WRITE = /^(PATCH|POST|DELETE) /;
+
+/** The notes channel is a line array; a test asserting a phrase reads the joined text. */
+const stderr = (out: {readonly stderr: ReadonlyArray<string>}): string => out.stderr.join("\n");
+const SERVED: HttpReply = {status: 200, body: "{}"};
+const BAD_GATEWAY: HttpReply = {status: 502, body: '{"message":"Bad gateway"}'};
+
+const env = {
+	CLAUDE_PIPELINE_REPO: "o/r",
+	CLAUDE_CODE_SESSION_ID: SESSION,
+	GITHUB_TOKEN: "ghp_scripted",
+} as Record<string, string | undefined>;
+
+const options = {number: 4300, token: TOKEN, repo: null, env};
+
+const run = (script: ReadonlyArray<Scripted>) =>
+	Effect.runPromise(Effect.provide(runRestage(options), planSeams(script).layer));
+
+/** This lane's claim on the epic — every mutation the group makes is gated on it. */
+const CLAIMED: ReadonlyArray<Scripted> = [
+	[COMMENTS, comments({id: 1, body: marker(SESSION, LANE_UUID)})],
+	[PERM, {status: 200, body: '{"permission":"write"}'}],
+];
+
+const TOPOLOGY = "- phase 1: #4301\n- phase 2: #4302\n- #4302 requires: #4301";
+
+const epicWith = (dependencies = TOPOLOGY): HttpReply => epic({body: epicBody({dependencies})});
+
+/** The sub-issue link list, each child carrying the close facts the reconcile is derived from. */
+const links = (
+	...rows: ReadonlyArray<{number: number; state?: string; stateReason?: string | null}>
+): HttpReply => ({
+	status: 200,
+	body: JSON.stringify(
+		rows.map((row) => ({
+			number: row.number,
+			title: `child ${row.number}`,
+			state: row.state ?? "open",
+			state_reason: row.stateReason ?? null,
+		})),
+	),
+});
+
+const LIVE = links({number: 4301}, {number: 4302});
+const ABANDONED = links({number: 4301}, {number: 4302, state: "closed", stateReason: "duplicate"});
+
+describe("runRestage", () => {
+	it("drops an abandoned child, proves the write, and names what moved", async () => {
+		const restaged = epicBody({dependencies: "- phase 1: #4301"});
+		const out = await run([
+			[once(EPIC), epicWith()],
+			...CLAIMED,
+			[SUBS, ABANDONED],
+			[PATCH, SERVED],
+			[EPIC, epic({body: restaged})],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "restaged",
+			epic: 4300,
+			dropped: [4302],
+			kept: [4301],
+			written: true,
+			verified: true,
+		});
+	});
+
+	it("answers unchanged and issues no PATCH over a consistent topology", async () => {
+		const seams = planSeams([[EPIC, epicWith()], ...CLAIMED, [SUBS, LIVE]]);
+		const out = await Effect.runPromise(Effect.provide(runRestage(options), seams.layer));
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "unchanged",
+			epic: 4300,
+			dropped: [],
+			kept: [4301, 4302],
+			written: false,
+		});
+		expect(seams.http.calls.some((call) => ANY_WRITE.test(call))).toBe(false);
+	});
+
+	it("keeps a child closed as completed — its region boots landed, not frozen", async () => {
+		const out = await run([
+			[EPIC, epicWith()],
+			...CLAIMED,
+			[SUBS, links({number: 4301, state: "closed", stateReason: "completed"}, {number: 4302})],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).answer).toBe("unchanged");
+	});
+
+	it("refuses on 7 when the body carries no ## Dependencies region at all", async () => {
+		const out = await run([
+			[EPIC, epic({body: "An epic nobody planned.\n"})],
+			...CLAIMED,
+			[SUBS, ABANDONED],
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(stderr(out)).toContain("carries no `## Dependencies` region");
+	});
+
+	it("refuses on 26 when two headings leave the region with no single meaning", async () => {
+		const twice = `${epicBody({dependencies: "- phase 1: #4301"})}\n## Dependencies\n\n- phase 1: #4302\n`;
+		const out = await run([[EPIC, epic({body: twice})], ...CLAIMED, [SUBS, ABANDONED]]);
+		expect(out.code).toBe(REGION_UNRESOLVABLE);
+		expect(stderr(out)).toContain("no single meaning");
+	});
+
+	it("refuses on 27 rather than writing a topology with no phase left", async () => {
+		const out = await run([
+			[EPIC, epicWith("- phase 1: #4301, #4302")],
+			...CLAIMED,
+			[
+				SUBS,
+				links(
+					{number: 4301, state: "closed", stateReason: "duplicate"},
+					{number: 4302, state: "closed", stateReason: "not_planned"},
+				),
+			],
+		]);
+		expect(out.code).toBe(TOPOLOGY_EMPTIED);
+		expect(stderr(out)).toContain("re-plan the epic instead");
+	});
+
+	it("refuses on 4 over an unparseable block, writing nothing", async () => {
+		const out = await run([[EPIC, epicWith("- phase one: #4301")], ...CLAIMED, [SUBS, ABANDONED]]);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(stderr(out)).toContain("nothing was written");
+	});
+
+	it("refuses on 7 over zero sub-issue children", async () => {
+		const out = await run([[EPIC, epicWith()], ...CLAIMED, [SUBS, links()]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(stderr(out)).toContain("zero sub-issue children");
+	});
+
+	it("refuses on 15 when another lane holds the claim", async () => {
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runRestage({...options, token: `build:${SESSION}:00000000-0000-4000-8000-000000000000`}),
+				planSeams([[EPIC, epicWith()], ...CLAIMED]).layer,
+			),
+		);
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+	});
+
+	it("is UNKNOWN, never a clean answer, when the sub-issue list cannot be read", async () => {
+		const out = await run([[EPIC, epicWith()], ...CLAIMED, [SUBS, BAD_GATEWAY]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(stderr(out)).toContain("nothing was written");
+	});
+
+	it("calls a PATCH it cannot confirm UNKNOWN rather than written", async () => {
+		const out = await run([
+			[EPIC, epicWith()],
+			...CLAIMED,
+			[SUBS, ABANDONED],
+			[PATCH, BAD_GATEWAY],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+	});
+
+	it("reds when the body does not read back as composed", async () => {
+		const out = await run([[EPIC, epicWith()], ...CLAIMED, [SUBS, ABANDONED], [PATCH, SERVED]]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(stderr(out)).toContain("needs a human eye");
+	});
+});

--- a/packages/fabrika-cli/src/plan/restage.ts
+++ b/packages/fabrika-cli/src/plan/restage.ts
@@ -1,0 +1,159 @@
+/**
+ * The pure half of `plan restage` — an epic body and its observed child links in, the same body with
+ * its `## Dependencies` region reconciled out.
+ *
+ * **What "reconciled" means is one rule: a ref the board proves closed without landing is dropped.**
+ * `lane emit` boots a child's region from that child's close reason — `completed` boots `landed`, and
+ * every other close boots `frozen`, a final carrying a door, which trips the phase the instant the
+ * machine starts. So an epic whose plan still names a child somebody closed as a duplicate can only
+ * emit a machine that trips, and until this verb existed the sole repair was a human editing the
+ * epic body by hand. A `completed` close is **kept**: its region boots `landed`, the phase folds, and
+ * dropping it would erase the sequencing the children after it were planned behind.
+ *
+ * **A ref the observation set does not name is left exactly as it is.** The observations are the
+ * epic's native sub-issue links, which is the same set `lane emit` checks every ref against, so the
+ * two can never disagree about one edge. A `requires:` pointing at another epic's issue, or a
+ * ledger-local `C<int>`, is not observed here and is not judged here — `lane emit`'s own `Foreign`
+ * arm is what reports it, and a reconcile that guessed at an unobserved ref would be rewriting a
+ * plan on no evidence.
+ *
+ * **Nothing outside the region is touched, and an unchanged topology composes no body at all.** The
+ * span comes from `build/dependencies.ts`, the one module that states where the section ends, so
+ * this writer and every reader cut at the same byte.
+ */
+
+import {
+	type Edge,
+	type Ref,
+	readTopology,
+	renderTopologyBlock,
+	topologySpans,
+} from "../build/dependencies.ts";
+import {preservedEnvelope} from "../triage/enrich.ts";
+
+/** One child link as the board reports it — `plan/github.ts`'s `SubIssueLink`, narrowed to what is judged. */
+export interface Observed {
+	readonly number: number;
+	readonly state: "open" | "closed";
+	readonly stateReason: string | null;
+}
+
+export type Restage =
+	| {
+			readonly _tag: "Restaged";
+			readonly body: string;
+			/** The issues the reconcile removed, ascending. */
+			readonly dropped: ReadonlyArray<number>;
+			/** The issues the reconciled region still names, ascending. */
+			readonly kept: ReadonlyArray<number>;
+	  }
+	/** Every ref the region names is still live — the idempotent no-op, and nothing is written. */
+	| {readonly _tag: "Unchanged"; readonly kept: ReadonlyArray<number>}
+	/** Dropping the abandoned refs would leave no phase at all — a plan to re-plan, not to rewrite. */
+	| {readonly _tag: "Emptied"; readonly dropped: ReadonlyArray<number>}
+	/** The body carries no `## Dependencies` heading. */
+	| {readonly _tag: "Absent"}
+	/** It carries more than one, so the region has no single meaning. */
+	| {readonly _tag: "Ambiguous"; readonly count: number}
+	/** The only one sits inside the preserved brief — that is filed content, not a machine-owned region. */
+	| {readonly _tag: "InPreservedBrief"}
+	| {readonly _tag: "Unparseable"; readonly line: number; readonly text: string}
+	/** The composed region does not parse back to the edges it was composed from. */
+	| {readonly _tag: "ReadbackMismatch"};
+
+/** Closed for a reason other than `completed` — closed without landing, in `lane emit`'s own terms. */
+const abandonedIn = (observations: ReadonlyArray<Observed>): ReadonlySet<number> =>
+	new Set(
+		observations
+			.filter((link) => link.state === "closed" && link.stateReason !== "completed")
+			.map((link) => link.number),
+	);
+
+const refsOf = (edge: Edge): ReadonlyArray<Ref> =>
+	edge._tag === "Phase" ? edge.members : [edge.subject, ...edge.needs];
+
+const issueNumbers = (edges: ReadonlyArray<Edge>): ReadonlyArray<number> =>
+	[
+		...new Set(
+			edges.flatMap((edge) =>
+				refsOf(edge).flatMap((ref) => (ref._tag === "Issue" ? [ref.number] : [])),
+			),
+		),
+	].sort((a, b) => a - b);
+
+/**
+ * The edge list with every abandoned ref removed.
+ *
+ * A phase line that loses every member disappears, and so does a `requires:` line whose subject was
+ * dropped or whose needs all were — a line naming nothing is not an edge, and leaving an empty one
+ * behind would not parse back.
+ */
+const filterEdges = (
+	edges: ReadonlyArray<Edge>,
+	abandoned: ReadonlySet<number>,
+): ReadonlyArray<Edge> => {
+	const alive = (ref: Ref): boolean => !(ref._tag === "Issue" && abandoned.has(ref.number));
+	const kept: Edge[] = [];
+	for (const edge of edges) {
+		if (edge._tag === "Phase") {
+			const members = edge.members.filter(alive);
+			if (members.length > 0) kept.push({...edge, members});
+			continue;
+		}
+		if (!alive(edge.subject)) continue;
+		const needs = edge.needs.filter(alive);
+		if (needs.length > 0) kept.push({...edge, needs});
+	}
+	return kept;
+};
+
+/**
+ * Reconcile the body's `## Dependencies` region against the observations.
+ *
+ * `body` is normalized to LF first, so the composed body a caller compares its read-back against is
+ * the one this function produced rather than one line-ending convention read as another.
+ */
+export const restageBody = (body: string, observations: ReadonlyArray<Observed>): Restage => {
+	const normalized = body.replace(/\r\n/g, "\n");
+	const lines = normalized.split("\n");
+	const spans = topologySpans(normalized);
+	const span = spans[0];
+	if (span === undefined) return {_tag: "Absent"};
+	if (spans.length > 1) return {_tag: "Ambiguous", count: spans.length};
+
+	const envelope = preservedEnvelope(lines);
+	if (envelope !== null && span.heading > envelope.start && span.heading < envelope.end) {
+		return {_tag: "InPreservedBrief"};
+	}
+
+	const topology = readTopology(normalized);
+	if (topology._tag === "Absent") return {_tag: "Absent"};
+	if (topology._tag === "Unparseable") {
+		return {_tag: "Unparseable", line: topology.line, text: topology.text};
+	}
+
+	const abandoned = abandonedIn(observations);
+	const named = issueNumbers(topology.edges);
+	const dropped = named.filter((number) => abandoned.has(number));
+	if (dropped.length === 0) return {_tag: "Unchanged", kept: named};
+
+	const filtered = filterEdges(topology.edges, abandoned);
+	if (!filtered.some((edge) => edge._tag === "Phase")) return {_tag: "Emptied", dropped};
+
+	const block = renderTopologyBlock(filtered);
+	const reparsed = readTopology(block);
+	if (reparsed._tag !== "Parsed" || renderTopologyBlock(reparsed.edges) !== block) {
+		return {_tag: "ReadbackMismatch"};
+	}
+
+	const before = lines.slice(0, span.heading).join("\n").replace(/\s+$/, "");
+	const after = lines.slice(span.end).join("\n").replace(/^\n+/, "");
+	const head = before === "" ? "" : `${before}\n\n`;
+	const tail = after.trim() === "" ? "" : `\n${after}`;
+	return {
+		_tag: "Restaged",
+		body: `${head}${block}${tail}`,
+		dropped,
+		kept: issueNumbers(filtered),
+	};
+};

--- a/packages/fabrika-cli/src/plan/restage.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/restage.unit.test.ts
@@ -1,0 +1,194 @@
+import {describe, expect, it} from "vitest";
+import {emitMachine} from "../lane/emit.ts";
+import {type Observed, restageBody} from "./restage.ts";
+
+const open = (number: number): Observed => ({number, state: "open", stateReason: null});
+const closed = (number: number, stateReason: string | null): Observed => ({
+	number,
+	state: "closed",
+	stateReason,
+});
+
+const body = (dependencies: string, options: {before?: string; after?: string} = {}): string =>
+	[
+		options.before ?? "An epic.",
+		"",
+		"## Dependencies",
+		"",
+		dependencies,
+		...(options.after === undefined ? [] : ["", options.after]),
+		"",
+	].join("\n");
+
+const PHASES = ["- phase 1: #1", "- phase 2: #2, #3", "- #3 requires: #2"].join("\n");
+
+describe("restageBody", () => {
+	it("drops a child closed for any reason other than completed", () => {
+		const out = restageBody(body(PHASES), [open(1), closed(2, "duplicate"), open(3)]);
+		expect(out).toMatchObject({_tag: "Restaged", dropped: [2], kept: [1, 3]});
+		if (out._tag !== "Restaged") return;
+		expect(out.body).toContain("- phase 1: #1");
+		expect(out.body).toContain("- phase 2: #3");
+		expect(out.body).not.toContain("#2");
+	});
+
+	it("keeps a completed close, whose region boots landed rather than frozen", () => {
+		expect(restageBody(body(PHASES), [closed(1, "completed"), open(2), open(3)])).toEqual({
+			_tag: "Unchanged",
+			kept: [1, 2, 3],
+		});
+	});
+
+	it("writes nothing over an already-consistent topology", () => {
+		expect(restageBody(body(PHASES), [open(1), open(2), open(3)])).toEqual({
+			_tag: "Unchanged",
+			kept: [1, 2, 3],
+		});
+	});
+
+	it("is idempotent: restaging its own output is a no-op", () => {
+		const observations = [open(1), closed(2, "not_planned"), open(3)];
+		const first = restageBody(body(PHASES), observations);
+		if (first._tag !== "Restaged") throw new Error(`expected Restaged, got ${first._tag}`);
+		expect(restageBody(first.body, observations)).toEqual({_tag: "Unchanged", kept: [1, 3]});
+	});
+
+	it("drops a requires: line whose subject went, and one whose needs all went", () => {
+		const out = restageBody(
+			body(
+				["- phase 1: #1, #2", "- phase 2: #3", "- #3 requires: #1", "- #2 requires: #1"].join("\n"),
+			),
+			[closed(1, "duplicate"), open(2), open(3)],
+		);
+		expect(out).toMatchObject({_tag: "Restaged", dropped: [1], kept: [2, 3]});
+		if (out._tag !== "Restaged") return;
+		expect(out.body).toContain("- phase 1: #2");
+		expect(out.body).toContain("- phase 2: #3");
+		expect(out.body).not.toContain("requires");
+	});
+
+	it("drops a phase line that loses every member", () => {
+		const out = restageBody(body("- phase 1: #1\n- phase 2: #2"), [
+			closed(1, "duplicate"),
+			open(2),
+		]);
+		expect(out).toMatchObject({_tag: "Restaged", dropped: [1], kept: [2]});
+		if (out._tag !== "Restaged") return;
+		expect(out.body).not.toContain("phase 1");
+		expect(out.body).toContain("- phase 2: #2");
+	});
+
+	/**
+	 * The observations are the epic's sub-issue links, which is the set `lane emit` checks against.
+	 * A ref outside them is unobserved, not abandoned, so a reconcile that dropped it would be
+	 * rewriting a plan on no evidence.
+	 */
+	it("leaves a ref the observations do not name exactly as written", () => {
+		const out = restageBody(body("- phase 1: #1, #9\n- phase 2: #2\n- #2 requires: C7"), [
+			open(1),
+			closed(2, "duplicate"),
+		]);
+		expect(out).toMatchObject({_tag: "Restaged", dropped: [2]});
+		if (out._tag !== "Restaged") return;
+		expect(out.body).toContain("- phase 1: #1, #9");
+		expect(out.body).not.toContain("C7");
+	});
+
+	it("round-trips a ledger-local ref rather than losing it", () => {
+		const out = restageBody(body("- phase 1: #1, C2\n- phase 2: #3"), [
+			open(1),
+			closed(3, "duplicate"),
+		]);
+		expect(out).toMatchObject({_tag: "Restaged", dropped: [3], kept: [1]});
+		if (out._tag !== "Restaged") return;
+		expect(out.body).toContain("- phase 1: #1, C2");
+	});
+
+	it("preserves every byte outside the region", () => {
+		const out = restageBody(
+			body("- phase 1: #1\n- phase 2: #2", {before: "The brief.", after: "## Notes\n\nKeep me."}),
+			[open(1), closed(2, "duplicate")],
+		);
+		if (out._tag !== "Restaged") throw new Error(`expected Restaged, got ${out._tag}`);
+		expect(out.body.startsWith("The brief.")).toBe(true);
+		expect(out.body).toContain("## Notes\n\nKeep me.");
+	});
+
+	it("refuses rather than emptying the topology to nothing", () => {
+		expect(
+			restageBody(body("- phase 1: #1, #2"), [closed(1, "duplicate"), closed(2, null)]),
+		).toEqual({_tag: "Emptied", dropped: [1, 2]});
+	});
+
+	it("names an absent region, an ambiguous one, and an unparseable line apart", () => {
+		expect(restageBody("An epic with no plan.\n", [open(1)])).toEqual({_tag: "Absent"});
+		expect(
+			restageBody("## Dependencies\n\n- phase 1: #1\n\n## Dependencies\n\n- phase 1: #2\n", [
+				closed(1, "duplicate"),
+			]),
+		).toEqual({_tag: "Ambiguous", count: 2});
+		expect(restageBody(body("- phase one: #1"), [closed(1, "duplicate")])).toMatchObject({
+			_tag: "Unparseable",
+			text: "- phase one: #1",
+		});
+	});
+
+	/** A heading inside the preserved brief is filed content — cutting there is how a body is destroyed. */
+	it("refuses a heading that resolves inside the preserved brief envelope", () => {
+		const filed = [
+			"An epic.",
+			"",
+			"<!-- fabrika:enriched issue=4300 mode=rewrite -->",
+			"<details>",
+			"<summary>Original report (verbatim)</summary>",
+			"",
+			"## Dependencies",
+			"",
+			"- phase 1: #1",
+			"",
+			"</details>",
+			"",
+		].join("\n");
+		expect(restageBody(filed, [closed(1, "duplicate")])).toEqual({_tag: "InPreservedBrief"});
+	});
+});
+
+/**
+ * The reconcile's whole point, asserted where the two modules meet rather than in either alone: what
+ * `lane emit` does with the region afterwards. `emitMachine` boots a non-`completed` close in
+ * `frozen`, a final carrying a door, so the phase trips at startup — that is the failure a hand edit
+ * to the epic body used to be the only cure for.
+ */
+describe("restageBody feeding lane emit", () => {
+	const EPIC = 4300;
+	const planned = body("- phase 1: #4301, #4302\n- phase 2: #4303\n- #4303 requires: #4301");
+	const observations = [open(4301), closed(4302, "duplicate"), open(4303)];
+
+	const initials = (text: string): Record<string, unknown> => {
+		const doc = JSON.parse(text) as {
+			machine: {states: Record<string, {states?: Record<string, {initial: string}>}>};
+		};
+		const out: Record<string, unknown> = {};
+		for (const phase of Object.values(doc.machine.states)) {
+			for (const [task, node] of Object.entries(phase.states ?? {})) out[task] = node.initial;
+		}
+		return out;
+	};
+
+	it("emits a frozen boot over the un-reconciled body", () => {
+		const emitted = emitMachine(EPIC, planned, observations);
+		if (emitted._tag !== "Emitted") throw new Error(`expected Emitted, got ${emitted._tag}`);
+		expect(initials(emitted.text).issue_4302).toBe("frozen");
+	});
+
+	it("emits regions for the live children only once the body is reconciled", () => {
+		const restaged = restageBody(planned, observations);
+		if (restaged._tag !== "Restaged") throw new Error(`expected Restaged, got ${restaged._tag}`);
+		const emitted = emitMachine(EPIC, restaged.body, observations);
+		if (emitted._tag !== "Emitted") throw new Error(`expected Emitted, got ${emitted._tag}`);
+		const booted = initials(emitted.text);
+		expect(booted).not.toHaveProperty("issue_4302");
+		expect(booted).toMatchObject({issue_4301: "queued", issue_4303: "queued"});
+		expect(Object.values(booted)).not.toContain("frozen");
+	});
+});

--- a/packages/fabrika-cli/src/triage/enrich.ts
+++ b/packages/fabrika-cli/src/triage/enrich.ts
@@ -43,6 +43,29 @@ export const MARKER_RE = /^<!-- fabrika:enriched issue=(\d+) mode=(rewrite|wrap)
 export const renderMarker = (issue: number, mode: EnrichMode): string =>
 	`<!-- fabrika:enriched issue=${issue} mode=${mode} -->`;
 
+/**
+ * The `[start, end]` line span of the preserved brief, or `null` when the body carries no marker.
+ *
+ * Both bounds are inclusive line indices: `start` is the marker line, `end` the `</details>` that
+ * closes the block below it — or `start` again where the closer is missing, which is an empty span
+ * rather than a swallowed rest-of-body.
+ *
+ * It lives here rather than beside either caller because the envelope is this module's shape: the
+ * marker is the boundary. Every verb that resolves a region in an epic body needs the bound — a
+ * heading that resolves *inside* the preserved brief is content, not this run's anchor — and two
+ * copies of that rule is two answers about which bytes are safe to overwrite.
+ */
+export const preservedEnvelope = (
+	lines: ReadonlyArray<string>,
+): {readonly start: number; readonly end: number} | null => {
+	const start = lines.findIndex((line) => MARKER_RE.test(line.trim()));
+	if (start === -1) return null;
+	const closing = lines.findIndex(
+		(line, index) => index > start && line.trim().toLowerCase() === "</details>",
+	);
+	return {start, end: closing === -1 ? start : closing};
+};
+
 export type Detection =
 	/** No enrichment of *this* issue is present, so the whole body is the original to preserve. */
 	| {


### PR DESCRIPTION
Closing an epic child left the epic's `## Dependencies` region naming it, and no verb could fix that.
`lane emit` boots each child's region from its close reason — `completed` boots `landed`, every other
close boots `frozen`, a final carrying a door — so an epic that lost a child to a duplicate close
could only ever emit a machine that trips the instant it starts. The one repair was a human editing
the epic body by hand.

`fabrika plan restage <epic> --token <claim>` is that repair, and nothing more:

- It drops every ref the epic's own native sub-issue links prove **closed for a reason other than
  `completed`**. That is `lane emit`'s boot rule read backwards, so the two can never disagree.
- A `completed` close is **kept** — its region boots `landed`, the phase folds, and dropping it would
  erase the sequencing the children planned behind it depend on.
- A phase line that loses every member disappears, and so does a `requires:` line whose subject was
  dropped or whose needs all were.
- A ref the link list does not name — a cross-epic prerequisite, a ledger-local `C<int>` — is
  **unobserved, not abandoned**, and is round-tripped exactly as written. `lane emit`'s own `Foreign`
  arm is what reports it.
- Idempotence is decided on the **refs**, never the bytes: a region naming only live issues answers
  `unchanged` and issues no PATCH, so a re-run neither reformats the block nor moves the body digest
  a standing approval binds.
- Refusals, all before any write: `7` no region at all (plan the epic first), `26` two headings or a
  heading inside the preserved brief envelope, `27` restaging would leave no phase at all, `4`
  unparseable block, `9` the composed region does not parse back or the body does not read back.

Two shared modules deepen rather than gain a second copy of a rule. `build/dependencies.ts` — the
canonical statement of where the section ends — now also exports that span and a block renderer, so
the writer and every reader cut at the same byte and a ledger-local ref survives the round trip.
The preserved-brief envelope finder moves out of `ledger/region.ts` into `triage/enrich.ts`, where
the marker that *defines* the envelope already lives; `ledger/region.ts` calls it instead of keeping
its own copy.

Where to look first: `packages/fabrika-cli/src/plan/restage.ts` is the whole decision, and the
`restageBody feeding lane emit` block in `restage.unit.test.ts` asserts the criterion that spans both
modules — the same body emits a `frozen` boot before the reconcile and none after it.

Fixes #7009

## Deviations

- **Out-of-scope change** — **Said:** the issue asks for one reconcile verb. **Did:** also added the
  missing `plan approve` and `plan approval` rows to the `plan` group's table in
  `docs/verb-reference.md`. **Why:** both verbs ship today and neither was listed; I was editing that
  exact table to add `plan restage`, and leaving a table I just touched two rows short would send a
  reader to a group whose contents it misstates. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about the `check-epic-plan` contract's self-test.
  **Did:** rewrote its clause 3 from "All four run `resolveTargetRepo`…" to a form that holds over
  every verb in the group. **Why:** the clause already counted wrong (six verbs, not four) and adding
  a seventh made a stale sentence into a false one about the code I am landing. **Disposition:**
  stated here.
- **Scope narrowing** — **Said:** reconcile "the observed state of the issues it names". **Did:**
  observed only the epic's native sub-issue links; a ref outside that set is round-tripped untouched
  rather than judged. **Why:** that link set is exactly what `lane emit` checks every ref against, so
  restaging against the same set is what keeps the two from disagreeing about one edge, and a
  cross-epic `requires:` prerequisite is a sanctioned edge the reconcile has no evidence to drop.
  **Disposition:** stated here, and stated in the verb's `--help` and in the contract section.
