### PR TITLE
fix: A restored chat window that had paged back cannot page back again: atOldest is checkpointed, the paged rows are not

### DIFF
--- a/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/chat-window.unit.test.tsx
@@ -898,6 +898,33 @@ describe("paging", () => {
 		expect(screen.queryByRole("button", {name: "Load earlier messages"})).toBeNull();
 		expect(screen.queryByText("Loading earlier messages…")).toBeNull();
 	});
+
+	// The slot of a window that had walked to the beginning of history before the desk stopped. The
+	// rows that walk produced are this window's React state and are gone, so a restored `atOldest`
+	// suppressed the one affordance that could fetch them and stranded the whole transcript before
+	// the live tail (#9047).
+	it("offers the head row to a window restored from a slot that says it reached the oldest page", async () => {
+		const {process, view, answerPage} = await openWindow(
+			withTranscript(transcriptOf(4)),
+			{pageLimit: 25},
+			{...initialChatView, pinned: false, scroll: 4213, cursor: "i0", atOldest: true},
+		);
+		const older = await screen.findByRole("button", {name: "Load earlier messages"});
+
+		await act(async () => {
+			fireEvent.click(older);
+		});
+		await waitFor(() => expect(process.inbox()).toEqual([{type: "page", before: "i0", limit: 25}]));
+		await act(async () => {
+			await answerPage(
+				withTranscript(transcriptOf(4), {lastPage: page, pageOutcome: {status: "success", page}}),
+			);
+		});
+		await waitFor(() => expect(view().cursor).toBe("p0"));
+		// The slot's own walk is re-derived from the rows this window now holds, not carried over.
+		expect(view().atOldest).toBe(false);
+		expect(await screen.findByText("older prompt")).toBeDefined();
+	});
 });
 
 describe("a fold closing under the reader", () => {

--- a/apps/tuval/src/shell/chat/subagent-list.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/subagent-list.unit.test.tsx
@@ -224,27 +224,21 @@ describe("a subagent's rows in the agent window", () => {
 			{subagentList: true},
 			{
 				...initialChatView,
-				atOldest: true,
 				unfolded: ["agent", "inner"],
 			},
 		);
 		expect(screen.queryByText("done")).toBeNull();
 		expect(document.querySelector('[data-nested="true"]')).toBeNull();
-		expect(transcriptIds()).toEqual(["user", "tool", "tool"]);
+		// A mounted window holds no walk however its slot was written (`./view.ts`, #9047), so the
+		// head row offering one leads every list of rows a mount renders.
+		expect(transcriptIds()).toEqual(["older", "user", "tool", "tool"]);
 		rendered.unmount();
 	});
 
 	// Q2: the head grows nothing in this PR. A finished worker's spawning call is the plain tool row
 	// it always was — no elapsed, no token readout, and no fold, because it heads no rows now.
 	it("leave the spawning call a plain tool row with no fold and no readout", async () => {
-		const {rendered} = await openWindow(
-			state("finished"),
-			{subagentList: true},
-			{
-				...initialChatView,
-				atOldest: true,
-			},
-		);
+		const {rendered} = await openWindow(state("finished"), {subagentList: true}, initialChatView);
 		expect(screen.queryByRole("button", {name: /nested calls?$/})).toBeNull();
 		expect(screen.queryByText(/elapsed/)).toBeNull();
 		expect(screen.queryByText(/tokens/)).toBeNull();
@@ -257,7 +251,6 @@ describe("a subagent's rows in the agent window", () => {
 			{subagentList: false},
 			{
 				...initialChatView,
-				atOldest: true,
 				unfolded: ["agent", "inner"],
 			},
 		);

--- a/apps/tuval/src/shell/chat/view.ts
+++ b/apps/tuval/src/shell/chat/view.ts
@@ -9,6 +9,13 @@
  * including `expanded`, which is why the same tool call can be open in one window and closed in the
  * other, and including `viewing`, which is what lets two windows sit on two different subagents.
  *
+ * Two of those seven do not survive a mount. The pages a window walked back to are the window's own
+ * React state, rebuilt empty every time it is mounted, so `cursor` and `atOldest` are read back as a
+ * fresh window's however the slot wrote them. Restored, they described rows the window did not hold,
+ * and `atOldest` is precisely what suppresses the affordance that could fetch them — so a window
+ * that had paged to the beginning of history came back holding the live tail and no route to the
+ * rest of the transcript (#9047).
+ *
  * `expanded` and `unfolded` are two facts, not one: opening a call's input panel and revealing the
  * subagent rows it heads are different asks, and one control doing both is what left the revealed
  * rows unannounced to assistive tech (#8027).
@@ -54,9 +61,16 @@ export type ChatView = {
 	 * refuses is still the operator's to take back (#8005).
 	 */
 	readonly outgoing: ReadonlyArray<OutgoingSend>;
-	/** The oldest item id this window has walked back to, or `null` while it holds only the live tail. */
+	/**
+	 * The oldest item id this window has walked back to, or `null` while it holds only the live tail.
+	 * Per-mount: the read-back answers `null` whatever the slot holds, because the pages it names are
+	 * not checkpointed beside it.
+	 */
 	readonly cursor: string | null;
-	/** The backend answered that there is nothing older; the transcript is at the beginning of history. */
+	/**
+	 * The backend answered that there is nothing older; the transcript is at the beginning of history.
+	 * Per-mount for the same reason as `cursor`, and the one that made restoring it a bug.
+	 */
 	readonly atOldest: boolean;
 	/** The ids of the rows this window has disclosed — a tool call's detail, a thinking row's text. */
 	readonly expanded: ReadonlyArray<string>;
@@ -117,8 +131,11 @@ export const asChatView = (value: ViewState | undefined): ChatView => {
 		scroll: typeof value.scroll === "number" && Number.isFinite(value.scroll) ? value.scroll : 0,
 		draft: typeof value.draft === "string" ? value.draft : "",
 		outgoing: asOutgoing(value.outgoing),
-		cursor: typeof value.cursor === "string" ? value.cursor : null,
-		atOldest: value.atOldest === true,
+		// Not read off the slot at all: the pages these two describe are the window's own React state,
+		// rebuilt empty on every mount, and a restored walk over no rows suppresses the affordance
+		// that could refill it (#9047).
+		cursor: initialChatView.cursor,
+		atOldest: initialChatView.atOldest,
 		expanded: Array.isArray(value.expanded)
 			? value.expanded.filter((id): id is string => typeof id === "string")
 			: [],

--- a/apps/tuval/src/shell/chat/view.unit.test.ts
+++ b/apps/tuval/src/shell/chat/view.unit.test.ts
@@ -26,11 +26,25 @@ describe("asChatView", () => {
 			scroll: 420,
 			draft: "hello",
 			outgoing: [{key: "k1", text: "unsent"}],
-			cursor: "i7",
-			atOldest: true,
+			cursor: null,
+			atOldest: false,
 			expanded: ["t1", "t2"],
 			unfolded: ["t3"],
 			viewing: null,
+		});
+	});
+
+	// The rows a walk produced are the window's own React state and are rebuilt empty at every mount,
+	// so a restored walk names rows the window does not hold — and `atOldest` is what suppresses the
+	// affordance that could fetch them (#9047).
+	it("answers a fresh walk however far back the slot says this window had paged", () => {
+		expect(asChatView({cursor: "i7", atOldest: true})).toEqual(initialChatView);
+		expect(asChatView({cursor: "i7", atOldest: false}).cursor).toBeNull();
+		expect(asChatView({scroll: 420, draft: "kept", atOldest: true})).toEqual({
+			...initialChatView,
+			pinned: true,
+			scroll: 420,
+			draft: "kept",
 		});
 	});
 
@@ -61,7 +75,7 @@ describe("asChatView", () => {
 			scroll: 12,
 			draft: "",
 			outgoing: [],
-			cursor: "i1",
+			cursor: null,
 			atOldest: false,
 			expanded: [],
 			unfolded: [],


### PR DESCRIPTION
Fixes #9047

A chat window's view slot checkpointed `cursor` and `atOldest`, but the rows those pages produced are
the window's own React state, rebuilt empty at every mount. A window restored after it had paged to
the beginning of history came back holding `atOldest: true` over no older rows — and that flag is
exactly what suppresses the `Load earlier messages` affordance and the automatic walk behind it. The
whole transcript before the live tail was unreachable in that window for the rest of its life.

`asChatView` now answers a fresh window's walk for both fields whatever the slot holds. The restored
paging state can no longer describe rows the window does not hold, because it restores none. Paging
inside one live session is untouched: after mount the pair is React state the window owns, so a page
that lands still prepends its rows and advances `cursor`, and the walk still drops the head row once
a page answers `hasMore: false`.

`view.ts`'s top docblock now says which two of its seven facts do not survive a mount, and the two
field comments say the same at their own lines.

## Verification

- `apps/tuval/src/shell/chat/chat-window.unit.test.tsx` mounts through `openWindow`'s `initialView`
  with `{cursor: "i0", atOldest: true}` over a store holding older rows, asserts the affordance
  renders, clicks it, and asserts the dispatched page prepends. Reverting only the `asChatView` hunk
  reds it at the `findByRole("button", {name: "Load earlier messages"})` — the affordance never
  appears.
- `apps/tuval/src/shell/chat/view.unit.test.ts` pins the new read-back answer directly.
- The `apps/tuval` unit suite is green (316 files, 3261 tests); `pnpm typecheck` and `pnpm lint` clean.
- `apps/tuval/src/shell/chat/proof/paging.tsx` re-run in a real Chromium over `pnpm proof:chat`:
  `/paging-prepend` reaches `prepended-same-anchor` with one request, `sameNode: true` and
  `otherWindowCursor: null` — so its in-session `right.view().cursor !== null` assertion still holds.
  `/paging-partial`, `/paging-local` and `/paging-completed` reach their own stages unchanged. The
  proof seeds both windows from `initialChatView`, so the read-back change is inert there.

## Deviations

- **Criterion discharged after the build** — **Said:** #9047 criterion 6 asks for a hand observation on a real agy desk under the #7306 exception, recording the view slot it was read against. **Did:** the builder shell could not open an agy session, so the observation was produced afterwards at this same head by a verification pass: https://github.com/kamp-us/phoenix/pull/9054#issuecomment-5621193329 (real agy 1.2.0, slot `atOldest: true` before and after restore, restored window offers `Load earlier messages` and pages 4 rows to 9; main on the same bytes offers none). **Why:** the desk needs a scratch `.gemini` home carrying `toolPermission` and a scratch desk config, which the verification pass set up without touching the founder's settings. **Disposition:** all seven criteria are met at 849f1534, so this PR now `Fixes` the issue.

- **Pre-existing test or fixture changed** — **Said:** #9047 names `view.ts`, its own test, and
  `chat-window.unit.test.tsx`. **Did:** also changed
  `apps/tuval/src/shell/chat/subagent-list.unit.test.tsx` — dropped three `atOldest: true` seeds from
  its `initialView` fixtures and added `"older"` to the one `transcriptIds()` assertion.
  **Why:** those seeds suppressed the head row through the read-back, which no longer restores the
  flag, so one case red on a row the fix correctly now renders; the seeds are inert either way.
  **Disposition:** stated here. The same now-inert seed survives in three other chat test files that
  assert nothing about row lists — filed as a follow-up rather than swept in here.

