### PR TITLE
fix: The review skill still tells a child's reviewer to post a review-ui verdict nothing reads

### DIFF
--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -52,6 +52,13 @@ the class the row printed; never derive one from your own reading of the diff. W
 a reviewer read `class code` as the whole bar, PASSed bare, and the merge gate refused on a
 `review-ui` namespace nobody had been told to route — a wasted ship dispatch and a park per PR.
 
+**On an epic child that arm does not exist, and the flag still goes on.** A child's region carries
+no `review:ui` cell ([`emit.ts`](../../../../packages/fabrika-cli/src/lane/emit.ts)), so on a child
+the class relays a fact rather than a route: `lane prove` hands `review-ui` to the epic's tail
+itself, whatever classes the event carries, and §6 says what you post in its place. Keep passing
+`--class ui` there anyway — it lands the `classes` field on the event line, and dropping it drops
+that record for nothing.
+
 `scope` also prints the head SHA, the issue reference (`fixes:<n>` / `part-of:<n>` / `-`), `self`,
 `harness`, and `governance\t<required|not-required>` — §6's trigger, and a different question from
 `harness`. Governance is never a `routed` row: it is derived-required at every round and fired
@@ -326,8 +333,9 @@ undisclosed that this gate could see"* — never "no deviations exist".
   **range's own changed paths** through the same `touchesGovernanceRoot` floor it uses on a PR
   ([`prove-verb.ts`](../../../../packages/fabrika-cli/src/lane/prove-verb.ts)) — a range touching a
   governance root derives `governance` exactly as a PR diff does. So post every namespace the range
-  derives over that range, on the child issue, with `--base`/`--tip` in place of `--sha`: yours
-  through `fabrika review post <child-issue> --namespace <ns> --base <b> --tip <t>`, governance's
+  derives **and that you may emit** over that range, on the child issue, with `--base`/`--tip` in
+  place of `--sha`: yours through
+  `fabrika review post <child-issue> --namespace <ns> --base <b> --tip <t>`, governance's
   through the `governance` skill's own range form (its §5). What binds is content, not a head alone.
   **A re-post over the
   same range appends exactly as the PR path does** — the prior verdict is retired below the fence,
@@ -336,11 +344,22 @@ undisclosed that this gate could see"* — never "no deviations exist".
   whole record of that child's review, with no PR surface holding a second copy. **§4's
   append takes the same pair** — `fabrika review append-criterion <child-issue> --base <b> --tip <t>
   --round <n>` — so an in-scope finding on a child binds the next round through the fences rather
-  than surviving as prose. Deferring the
-  namespace strands the lane whichever polarity you reached: a claimed `PASS` reds at `lane prove`
-  exit `23`, and a `FAIL` is recorded only once every derived namespace is terminal against the
-  range (`operate`'s `FAIL` row). The every-round rule above is unchanged here — a child's FAIL
-  round owes its governance verdict too.
+  than surviving as prose. Deferring a namespace you **do** owe strands the lane whichever polarity
+  you reached: a claimed `PASS` reds at `lane prove` exit `23`, and a `FAIL` is recorded only once
+  every namespace the child owes is terminal against the range (`operate`'s `FAIL` row). The
+  every-round rule above is unchanged here — a child's FAIL round owes its governance verdict too.
+- **`review-ui` is the namespace a child's range derives and does not owe, and on a child it is not
+  yours to chase.** A child opens no PR, and every verb that may post that namespace resolves live
+  PR state, so nothing can post `review-ui` at range scope at all: `review post`'s range arm fences
+  on the three text classes and refuses it `OFF_VOCABULARY`, and `review-ui post` takes no
+  `--base`/`--tip`. `lane prove` subtracts it from a child's bar itself
+  ([`prove.ts`](../../../../packages/fabrika-cli/src/lane/prove.ts), `claimOf`'s child arm), so a
+  claimed `PASS` proves with no `review-ui` record on the child, and a record posted there —
+  verdict or `routed-elsewhere` — is read by nothing. The creditor is the epic's tail: one epic run
+  is one branch and one PR, so every rendered file the child's range added sits in the tail PR's own
+  diff, where the tail's `PASS` derives `review-ui` and stands on it at a head a preview exists for.
+  So §1's `routed` reading holds here for the reason it holds anywhere — do not judge it, do not
+  emit it, and do not read its absence from a child's verdicts as a gap in yours.
 - **The tail's own review is a separate subject, so this is not a double post.** The tail PR's
   namespaces are derived from the tail PR's own diff and its verdicts are head-bound on that PR; a
   child's are derived from the child's range and are content-bound on the child issue. Posting on
@@ -463,7 +482,9 @@ owes, and your class flag is what decides that: a routed namespace is left to th
 only when the flag routes this very `PASS` into it, and out of `review:ui` the whole derived set must
 stand. Omit the flag on a rendered PR and the routed namespace is owed **here** — exit `23` naming
 it, with the flag as the remedy. The review bar splits across those two cells and the machine
-decides which one owes what; you relay the row, never the split.
+decides which one owes what; you relay the row, never the split. On an epic child the split is not
+the flag's: that `PASS` is proved against the range, and it defers the routed namespace whatever the
+flag says (§6).
 The merge gate re-derives all of it either way. A refusal is the PR disagreeing with your terminal: print the token, name the exit code,
 change nothing. Then print the terminal either way; a run whose caller named no lane prints it only
 and records nothing.

--- a/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
@@ -1501,6 +1501,26 @@ describe("lane prove — the epic tail keeps the PR arms", () => {
 		});
 		expect(seams.calls.some((line) => BRANCHES.test(line))).toBe(false);
 	});
+
+	/**
+	 * Where the ui-bearing child's deferral lands. The child hands `review-ui` on rather than
+	 * dropping it, so the tail — whose one PR carries those same rendered files — must still refuse
+	 * without it, at a head a preview exists for.
+	 */
+	it("still owes review-ui on the tail's own rendered head, so the child's deferral moved the gate", async () => {
+		const seams = fakeSeams([
+			[CLOSERS, closingPulls()],
+			[SEARCH, nominated(4318)],
+			[PULL, pull({body: "Fixes #4300\n\n## Deviations\nNone.\n"})],
+			[FILES, served([{filename: "apps/site/src/routes/page.tsx"}])],
+			[PR_COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`})],
+		]);
+
+		const out = await runEpic(epicLaneAt("tail"), seams, "PASS", "epic_4300");
+
+		expect(out.code).toBe(PROOF_IN_FLIGHT);
+		expect(out.stderr.join("\n")).toContain("review-ui (absent)");
+	});
 });
 
 /**


### PR DESCRIPTION
The `review` skill's text still described the old child bar. `lane prove`'s child arm defers
`review-ui` to the epic's tail, but the skill told a child's reviewer to "post every namespace the
range derives over that range, on the child issue" and warned that deferring one reds at `lane
prove` exit `23`. A reviewer following the letter chased a verdict no verb can write and the prover
does not want.

Three places now read what the code does:

- **§1** — a child's region carries no `review:ui` cell, so the class relay lands the `classes` field
  on the event line rather than taking an arm. Keep passing `--class ui`; it routes nothing there.
- **§6** — the post instruction is scoped to the namespaces you may emit, and a new bullet says
  `review-ui` is derived-but-not-owed on a child, why nothing can post it at range scope, and that
  the epic's tail is the creditor.
- **Terminal vocabulary** — the split between `review` and `review:ui` is the class flag's on a PR
  and the child's own shape on a child.

## Route taken, and the one rejected

**Deferral.** The code half of it already landed in #7332: `claimOf`'s child arm returns
`defers: ROUTED_NAMESPACES` and `proveRangeVerdicts` subtracts them. This PR is the text half plus
the test that deferral owed the tail — a ui-bearing tail head with no `review-ui` verdict still
refuses at exit `23`, so the gate moved rather than disappeared.

**Rejected: give a child a `review:ui` cell.** It would need a range form on `review-ui post` (a
content digest in place of a head SHA) and a machine arm a child's region does not have. A rendered
preview needs a head, and mid-run a child has none — one epic run is one branch and one PR, so the
tail PR's diff carries every rendered file the children added and the tail's `PASS` judges them at a
head a preview exists for. The wider change would buy an earlier gate on a surface nobody can render
yet.

## What a reviewer should look at first

Whether §6's new bullet and §1's new paragraph agree with `claimOf`'s child arm
(`packages/fabrika-cli/src/lane/prove.ts`) and with `operate`'s SKILL.md, which #7332 updated on the
same fact.

## Deviations

- **Scope narrowing** — **Said:** criteria 1 and 3 ask that a ui-bearing child reach `proven` and
  that a unit test cover a child range raising `ui` with no `review-ui` verdict. **Did:** verified
  both already hold on `main` and changed nothing for them. **Why:** #7332 landed the code half and
  its child tests before this lane opened; the issue's own 2026-09-10 amendment says the skill text
  is what is left. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** criterion 5 names §6's epic-child paragraph. **Did:** also
  fixed §1's routed-row paragraph and one sentence in the Terminal vocabulary. **Why:** both state
  the same wrong thing to a child's reviewer — that the class flag routes into `review:ui`, and that
  the flag decides the split — so fixing §6 alone leaves the contradiction two sections away.
  **Disposition:** stated here.

Fixes #6815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
