### PR TITLE
fix: Can't repair a failed decision child: the ruling link isn't passed

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -633,6 +633,17 @@ that same lane with `fabrika build resume-child <n> --token <token>`. **The toke
 re-run** — a bare `resume-child <n>` over a held claim mints a second one, loses the earliest-wins
 tiebreak to your own prior claim and refuses on `15`.
 
+**A `type:decision` child is repaired through the same entry, and it needs its ruling named.** The
+claim step's type axis binds here exactly as it binds a fresh claim, so an uncited decision child
+stops the entry at `30` — pass the ruling on `fabrika build resume-child <n> --cites <url>` and the
+entry carries it to that step and nowhere else. The refusal's own line prints the grammar, the URL
+has to name this repository and this child, and citing one buys nothing but that type: a malformed
+or foreign URL is `1` at the claim step, and no citation makes an epic or an out-of-scope child
+admissible. **Never assemble the five steps by hand to get a citation in** — that is the ordering
+hazard this entry retired, and the flag is the whole reason it no longer forces the choice. On a
+`--token` continuation you drop the citation: the claim answers off the standing marker, so the
+ruling is asked for on first entry only.
+
 `--resume` is checked against the board, not trusted: on a child holding no standing `FAIL` the claim
 step refuses on `31`, so the entry can never be run past the fence. `--resume-lane` **re-keys** the
 branch the prior lane built on to this claim's nonce instead of cutting a second one — two branches

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1694,7 +1694,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika build resume-child 9 [--token <token>]
+fabrika build resume-child 9 [--cites <url>] [--token <token>]
 ```
 
 **Inputs**
@@ -1703,6 +1703,7 @@ fabrika build resume-child 9 [--token <token>]
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic child whose standing-`FAIL` repair lane this opens |
 | `--token` | string | no | — | the repair claim this lane already holds, when it is re-running; the claim step then answers off the standing marker and writes nothing. Omitting it on a re-run over a held claim is not a shorter spelling of the same run: the claim step mints a second marker, loses the earliest-wins tiebreak to this lane's own prior claim and refuses on `15` |
+| `--cites` | string | no | — | the founder ruling comment a `type:decision` child's repair transcribes, as `https://github.com/<owner>/<repo>/issues/<n>#issuecomment-<comment-id>`. Carried to the claim step unchanged and read by no other step here; `build claim` binds it to this repository and this child and opens its type axis with it. Needed on a first entry only — a `--token` continuation answers off the standing marker, so the citation is not asked for twice |
 
 **Output** — machine. One JSON object:
 
@@ -1718,7 +1719,9 @@ established in sequence, and each step needs what the one before it produced:
 
 1. `build claim <n> --resume` — the repair claim. `--resume` is checked against the child's own
    range-scoped verdicts, so a child holding no standing `FAIL` refuses on `31` here, before any
-   marker is written.
+   marker is written. `--cites` rides here too, and only here: a `type:decision` child otherwise
+   refuses on `30`, which would leave a ruled decision the epic already built and a reviewer already
+   failed with no route through the one entry the skill sanctions.
 2. `build confirm <n> --token <won>` — the claim re-proved, before any mutation.
 3. `build tree --require-clean` — **unarmed**. No lane branch is checked out yet, so there is no lane
    identity to prove; this asserts only that the generic isolated checkout carries no unauthored hunk.
@@ -1734,7 +1737,10 @@ parking a whole epic without changing a file, while reading a `SKILL.md` that st
 order. A documented order is a claim about what an agent will do; this is a claim about what
 the tool does.
 
-**It sequences and derives nothing.** Every step is the same `run*` function the CLI leaf calls, so a
+**It sequences and derives nothing** — `--cites` included. The flag is carried to the claim step and
+judged only there, so a URL naming another repository or another issue is that step's `1`, an
+uncited decision child is still its `30`, and a citation admits no type `build claim` would not have
+admitted itself. Every step is the same `run*` function the CLI leaf calls, so a
 refusal keeps its own exit code, its own words and its own fail-closed reading. This verb adds one
 stderr line naming the step that stopped, and — once a claim has landed — one line spelling out both
 ways forward from a held claim, each with the won token already in it: the `--token` re-run that
@@ -1745,6 +1751,7 @@ branch is re-keyed only once the claim and cleanliness steps have passed.
 
 | Code | Trigger |
 |---|---|
+| `1` | `--cites` is malformed, or names another repository or another issue — `build claim`'s own refusal, at the claim step, before any marker |
 | `7` | the child is proven absent or closed, or no branch in this clone's refs was cut for it |
 | `10` | a composed usage refusal |
 | `11` | a read is UNKNOWN, several prior branches name the child, another worktree still holds the branch, or a composed verb answered outside its documented shape |
@@ -1774,6 +1781,18 @@ $ fabrika build resume-child 9
 {"answer":"resumed","issue":9,"token":"build:s-9f2e:c1a4d6f8-…","branch":"build/9-search-index-bootstrap-c1a4d6f8","root":"/abs/path","claim":{"number":9,"nonce":"c1a4d6f8"}}
 ```
 
+A ruled `type:decision` child, whose repair the type axis refuses without the ruling it transcribes:
+
+```
+$ fabrika build resume-child 9
+build resume-child: stopped at the claim step on exit 30; the steps after it did not run.
+build claim: type: type:decision — the type axis binds a build claim against an issue.
+build claim: type not buildable — this issue carries type:decision, whose deliverable is not a pull request an agent build lane produces; a decision is /adr's lane unless the choice is already recorded on it, in which case pass --cites https://github.com/<owner>/<repo>/issues/<n>#issuecomment-<comment-id> naming that founder ruling comment.
+$ fabrika build resume-child 9 --cites https://github.com/<owner>/<repo>/issues/9#issuecomment-5335398768
+build claim: type: type:decision — admitted as transcription of the founder ruling at https://github.com/<owner>/<repo>/issues/9#issuecomment-5335398768; the deliverable is that ruling written down, nothing more.
+{"answer":"resumed","issue":9,"token":"build:s-9f2e:c1a4d6f8-…","branch":"build/9-search-index-bootstrap-c1a4d6f8","root":"/abs/path","claim":{"number":9,"nonce":"c1a4d6f8"}}
+```
+
 ```
 $ fabrika build resume-child 9
 build resume-child: stopped at the clean-tree step on exit 13; the steps after it did not run.
@@ -1784,7 +1803,9 @@ $ echo $?
 ```
 
 The continuation that stop line names, after the tree was cleaned. The claim step answers off the
-standing marker and writes nothing, and the run goes on to the branch it stopped short of:
+standing marker and writes nothing — so a decision lane that stopped mid-sequence continues on this
+same command, with no citation and no second marker — and the run goes on to the branch it stopped
+short of:
 
 ```
 $ fabrika build resume-child 9 --token build:s-9f2e:c1a4d6f8-…

--- a/packages/fabrika-cli/docs/verb-reference.md
+++ b/packages/fabrika-cli/docs/verb-reference.md
@@ -96,7 +96,7 @@ Contract: [`skills/build/contract.md`](../../../claude-plugins/fabrika/skills/bu
 | `build claimants` | who holds an issue's claim, read by a caller holding none — no token, no write, no clearance |
 | `build issue` | the claimed issue's body and its criteria — `found` / `absent` / `malformed`, all on exit 0 |
 | `build branch` / `scratch` | the lane's branch off a fresh base it derives — `epic/<parent>` for an epic child, `origin/main` for a proven-standalone issue — fetched from a remote, named by commit in the answer, re-proved on a re-run, and its scratch directory |
-| `build resume-child` | an epic child's standing-`FAIL` repair lane, opened as one operation: claim, confirm, clean tree, resumed branch, armed proof |
+| `build resume-child` | an epic child's standing-`FAIL` repair lane, opened as one operation: claim, confirm, clean tree, resumed branch, armed proof — `--cites` carries a ruled `type:decision` child's founder ruling to the claim step |
 | `build commit` / `push` | the commit whose message is proven this lane's, and the push whose ref is proven moved |
 | `build check` | this surface's validators plus every shipped local-tree guard, run in this tree — each guard named in `ran`, or in `skipped` when it refused |
 | `build pr` / `pr-body` / `note` | the guarded, read-back PR write surfaces |

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -400,13 +400,20 @@ const resumeChild = leafCommand(
 				"the repair claim this lane already holds, when it is re-running — the claim step then answers off the standing marker and writes nothing; omit it on a first entry, but NOT on a re-run, where a tokenless claim mints a second marker and refuses on 15",
 			),
 		),
+		cites: Flag.string("cites").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				`the founder ruling comment a ${DECISION_TYPE_LABEL} child's repair transcribes, as ${CITATION_GRAMMAR} — forwarded unchanged to the claim step, which is the only step that reads it; needed on a first entry, never on a --token continuation`,
+			),
+		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({number, token, repo}) {
+	Effect.fn(function* ({number, token, cites, repo}) {
 		yield* emit(
 			yield* runResumeChild({
 				issue: number,
 				token: Option.getOrNull(token),
+				cites: Option.getOrNull(cites),
 				repo: Option.getOrNull(repo),
 				cwd: process.cwd(),
 				env: process.env,
@@ -418,7 +425,7 @@ const resumeChild = leafCommand(
 ).pipe(
 	Command.withShortDescription("Open an epic child's standing-FAIL repair lane in one operation."),
 	Command.withDescription(
-		'Open the repair lane of an epic child carrying a standing FAIL, running the five ordered steps as one operation so their order is not a builder\'s to preserve (see claude-plugins/fabrika/skills/build/contract.md): "build claim <n> --resume" (which refuses on 31 unless a gate holds a standing FAIL over the child), "build confirm", the UNARMED "build tree --require-clean" over the generic checkout, "build branch <n> --resume-lane" — the one mutation, which re-keys the single prior build/<n>-<slug>-<nonce> branch to this claim\'s nonce and checks it out — and finally the ARMED "build tree --issue <n>". Each step is the verb itself, so its refusal keeps its own exit code and its own words, and no step after a refusal runs; the branch is re-keyed only once the claim and cleanliness steps have passed. Prints {"answer":"resumed","issue":n,"token":"…","branch":"build/<n>-<slug>-<nonce>","root":"<absolute>","claim":{"number":n,"nonce":"…"}}. On any stop past the claim it prints the won token and the exact continuation, "fabrika build resume-child <n> --token <token>"; that is the whole way to continue the same lane, and a re-run WITHOUT --token mints a second claim, loses the earliest-wins tiebreak to this lane\'s own prior one and refuses on 15. Exits are the stopping step\'s: 7 (the child is absent or closed, or no local branch was cut for it), 10 (a composed usage refusal), 11 (a read is UNKNOWN, several prior branches exist, or another worktree holds the branch — an operator\'s act to release), 13 (the generic checkout is dirty), 14 (the armed proof reads the wrong lane), 15 (the claim is foreign), 20/21/30/32 (the admission test), 31 (the child holds no standing FAIL, so there is nothing to repair). Example: fabrika build resume-child 7162',
+		`Open the repair lane of an epic child carrying a standing FAIL, running the five ordered steps as one operation so their order is not a builder's to preserve (see claude-plugins/fabrika/skills/build/contract.md): "build claim <n> --resume" (which refuses on 31 unless a gate holds a standing FAIL over the child), "build confirm", the UNARMED "build tree --require-clean" over the generic checkout, "build branch <n> --resume-lane" — the one mutation, which re-keys the single prior build/<n>-<slug>-<nonce> branch to this claim's nonce and checks it out — and finally the ARMED "build tree --issue <n>". Each step is the verb itself, so its refusal keeps its own exit code and its own words, and no step after a refusal runs; the branch is re-keyed only once the claim and cleanliness steps have passed. Prints {"answer":"resumed","issue":n,"token":"…","branch":"build/<n>-<slug>-<nonce>","root":"<absolute>","claim":{"number":n,"nonce":"…"}}. --cites ${CITATION_GRAMMAR} is carried to the claim step unchanged and read by no other step: it opens that step's type axis on a ${DECISION_TYPE_LABEL} child whose choice a founder already recorded on it, so the one type a ruled child can carry is repairable through this entry rather than only by hand. It judges nothing itself — the URL must name this repository and this child, an omitted one on a decision is still 30, and a citation admits no other type. On any stop past the claim it prints the won token and the exact continuation, "fabrika build resume-child <n> --token <token>"; that is the whole way to continue the same lane, it needs no second citation because the claim answers off the standing marker, and a re-run WITHOUT --token mints a second claim, loses the earliest-wins tiebreak to this lane's own prior one and refuses on 15. Exits are the stopping step's: 1 (--cites is malformed, or names another repository or issue), 7 (the child is absent or closed, or no local branch was cut for it), 10 (a composed usage refusal), 11 (a read is UNKNOWN, several prior branches exist, or another worktree holds the branch — an operator's act to release), 13 (the generic checkout is dirty), 14 (the armed proof reads the wrong lane), 15 (the claim is foreign), 20/21/30/32 (the admission test), 31 (the child holds no standing FAIL, so there is nothing to repair). Example: fabrika build resume-child 7162`,
 	),
 );
 

--- a/packages/fabrika-cli/src/build/resume-child-verb.ts
+++ b/packages/fabrika-cli/src/build/resume-child-verb.ts
@@ -9,7 +9,9 @@
  *
  * It sequences and derives nothing. Every step is the verb a builder would have typed, called through
  * the same `run*` function the CLI calls, so each refusal keeps its own exit code, its own words and
- * its own fail-closed reading; this module adds only the line naming which step stopped.
+ * its own fail-closed reading; this module adds only the line naming which step stopped. `--cites`
+ * rides along on that same principle: the claim step's decision arm is the one admission a child
+ * repair can need, so the value is carried to it unchanged and judged only there.
  */
 import {Effect, type FileSystem, type Path} from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
@@ -35,6 +37,16 @@ export interface ResumeChildOptions {
 	 * tokenless re-run over a held claim posts a second marker and loses to the first on `15`.
 	 */
 	readonly token: string | null;
+	/**
+	 * The founder-ruling comment a `type:decision` child's repair transcribes — `null` on every other
+	 * type, and on a decision whose ruling nobody cited.
+	 *
+	 * Forwarded unchanged to the claim step and read by nothing else here. `build claim` binds the URL
+	 * to this repository and this child before it opens the type axis, so the wrapper carries the
+	 * value without judging it: a decision child that fails review is otherwise unrepairable through
+	 * the one sanctioned entry, because the arm its own `30` refusal names has no way in.
+	 */
+	readonly cites: string | null;
 	readonly repo: string | null;
 	/** Where to look for `ROADMAP.md` — the checkout this run stands in. */
 	readonly cwd: string;
@@ -97,7 +109,7 @@ export const runResumeChild = (
 			purpose: "build",
 			override: null,
 			overrideLane: null,
-			cites: null,
+			cites: options.cites,
 			token: options.token,
 			resume: true,
 		});

--- a/packages/fabrika-cli/src/build/resume-child-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/resume-child-verb.unit.test.ts
@@ -18,11 +18,13 @@ import {
 	once,
 	type Scripted,
 } from "../fakes.test-support.ts";
+import {FAILED} from "../verb.ts";
 import {
 	CLAIM_NOT_MINE,
 	DIRTY_TREE,
 	PRECONDITION_UNKNOWN,
 	PRIOR_BUILD_MISMATCH,
+	TYPE_NOT_BUILDABLE,
 	WRONG_LANE,
 	ZERO_SCOPE,
 } from "./codes.ts";
@@ -72,6 +74,11 @@ const ECHO = served({body: MINE});
 
 const labelled = (...names: ReadonlyArray<string>) => names.map((name) => ({name}));
 const CLAIMABLE = issue({labels: labelled("type:bug", "p1", "status:triaged", "ready-for:agent")});
+/** The shape that found this: a decision triage stamped for an agent once a founder had ruled on it. */
+const RULED_DECISION = issue({
+	labels: labelled("type:decision", "p1", "status:triaged", "ready-for:agent"),
+});
+const RULING = `https://github.com/o/r/issues/${CHILD}#issuecomment-5335398768`;
 
 const RANGE = "9f2c1ab4d5e6f708192a3b4c5d6e7f8091a2b3c4..03135b917283a4b5c6d7e8f90a1b2c3d4e5f6071";
 const rangeVerdict = (polarity: string) =>
@@ -92,6 +99,14 @@ const HOLDS_THE_CLAIM: ReadonlyArray<Scripted> = [
 	NO_BLOCKERS,
 ];
 
+/** The same standing marker, over the decision child — the continuation asks for no ruling again. */
+const HOLDS_THE_DECISION_CLAIM: ReadonlyArray<Scripted> = [
+	[COMMENTS, CLAIMED_THREAD],
+	[ISSUE, RULED_DECISION],
+	[PERM, WRITES],
+	NO_BLOCKERS,
+];
+
 /** No `ROADMAP.md`: the scope fence is inert, so this suite asks only about the sequence. */
 const NO_CAMPAIGNS = fakeFs({files: {}});
 
@@ -102,6 +117,17 @@ const WINS_THE_CLAIM: ReadonlyArray<Scripted> = [
 	[GET_COMMENT, ECHO],
 	[COMMENTS, CLAIMED_THREAD],
 	[ISSUE, CLAIMABLE],
+	[PERM, WRITES],
+	NO_BLOCKERS,
+];
+
+/** The same race, over a ruled decision child: only the type the issue carries differs. */
+const WINS_AS_DECISION: ReadonlyArray<Scripted> = [
+	[once(COMMENTS), graded("FAIL")],
+	[POST, POSTED],
+	[GET_COMMENT, ECHO],
+	[COMMENTS, CLAIMED_THREAD],
+	[ISSUE, RULED_DECISION],
 	[PERM, WRITES],
 	NO_BLOCKERS,
 ];
@@ -129,6 +155,7 @@ const GENERIC_CHECKOUT: ReadonlyArray<Scripted> = [
 const options = {
 	issue: CHILD,
 	token: null as string | null,
+	cites: null as string | null,
 	repo: null,
 	cwd: "/repo",
 	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e", ...GH_TOKEN_ENV} as Record<
@@ -372,5 +399,93 @@ describe("runResumeChild — continuing a lane that already holds its claim", ()
 		expect(shell.calls.findIndex((line) => SWITCH.test(line))).toBeLessThan(
 			shell.calls.findIndex((line) => ABBREV_REF.test(line)),
 		);
+	});
+});
+
+/**
+ * The citation passthrough, executed.
+ *
+ * A `type:decision` child is the common first child of an epic — a ruling gets recorded before the
+ * work it governs is built — so the first repair round of the common shape hit a `30` the entry had
+ * no flag to answer, and the only route left was hand-assembling the five steps this verb exists to
+ * take out of a builder's hands. What the coverage has to prove is that the value reaches the claim
+ * step and stops there: the arm opens, and nothing else about the fence moves.
+ */
+describe("runResumeChild — the ruled decision child's repair", () => {
+	it("opens the lane on a cited ruling, running the same sequence to the armed proof", async () => {
+		const {outcome, shell} = await run([...WINS_AS_DECISION, ...GENERIC_CHECKOUT], {
+			cites: RULING,
+		});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			answer: "resumed",
+			issue: CHILD,
+			token: LANE_TOKEN,
+			branch: RESUMED,
+			root: "/repo/trees/lane-a",
+			claim: {number: CHILD, nonce: NONCE},
+		});
+		expect(outcome.stderr.join("\n")).toContain(
+			`admitted as transcription of the founder ruling at ${RULING}`,
+		);
+		expect(shell.calls).toContain(`git branch -m ${PRIOR} ${RESUMED}`);
+		expect(shell.calls).toContain(`git switch ${RESUMED}`);
+	});
+
+	it("still refuses an uncited decision on 30, before any marker or git step", async () => {
+		const {outcome, shell} = await run([...WINS_AS_DECISION, ...GENERIC_CHECKOUT]);
+		expect(outcome.code).toBe(TYPE_NOT_BUILDABLE);
+		expect(outcome.stderr.join("\n")).toContain("type not buildable");
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it.each([
+		["malformed", "issues/4312#issuecomment-5335398768"],
+		["another repository's", "https://github.com/other/repo/issues/4312#issuecomment-5335398768"],
+		["another issue's", "https://github.com/o/r/issues/9999#issuecomment-5335398768"],
+	])("keeps build claim's own refusal for %s citation, moving no branch", async (_kind, cites) => {
+		const {outcome, shell} = await run([...WINS_AS_DECISION, ...GENERIC_CHECKOUT], {cites});
+		expect(outcome.code).toBe(FAILED);
+		expect(outcome.stderr.at(-1)).toContain("build claim: --cites");
+		expect(outcome.stderr.at(-1)).toContain("nothing was written");
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("leaves an ordinary bug child's repair unchanged, cited or not", async () => {
+		const bare = await run([...WINS_THE_CLAIM, ...GENERIC_CHECKOUT]);
+		const cited = await run([...WINS_THE_CLAIM, ...GENERIC_CHECKOUT], {cites: RULING});
+		expect(bare.outcome.code).toBe(0);
+		expect(cited.outcome.code).toBe(0);
+		expect(cited.outcome.stdout).toBe(bare.outcome.stdout);
+	});
+
+	it("admits no type a citation was never an arm for — an epic child is still 30", async () => {
+		const {outcome, shell} = await run(
+			[
+				[once(COMMENTS), graded("FAIL")],
+				[POST, POSTED],
+				[GET_COMMENT, ECHO],
+				[COMMENTS, CLAIMED_THREAD],
+				[ISSUE, issue({labels: labelled("type:epic", "p1", "status:triaged", "ready-for:agent")})],
+				[PERM, WRITES],
+				NO_BLOCKERS,
+				...GENERIC_CHECKOUT,
+			],
+			{cites: RULING},
+		);
+		expect(outcome.code).toBe(TYPE_NOT_BUILDABLE);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("continues the decision lane on --token alone, with no citation and no second marker", async () => {
+		const {outcome, shell} = await run([...HOLDS_THE_DECISION_CLAIM, ...GENERIC_CHECKOUT], {
+			token: LANE_TOKEN,
+		});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).branch).toBe(RESUMED);
+		expect(shell.requests.some((line) => POST.test(line))).toBe(false);
+		expect(outcome.stderr.join("\n")).toContain("already held by this lane");
 	});
 });

--- a/portability-guard.config.json
+++ b/portability-guard.config.json
@@ -146,8 +146,8 @@
 			]
 		},
 		"cli-tail": {
-			"ceiling": 4,
-			"why": "#8310 swept the remaining small groups and the top-level modules under src/ to four residues, none of them prose. All four are citation URLs under test in packages/fabrika-cli/src/decision — three in rule-verb.unit.test.ts and one in ruling-verb.unit.test.ts. `parseCitation` and `RULING_URL_RE` pin the github.com host in their own regexes, so a citation on any other host exercises nothing and the assertion stops testing what it names. Same class as the two build/ rows already carved out for it; the host pin itself is the portability defect, parked behind #8359.",
+			"ceiling": 7,
+			"why": "#8310 swept the remaining small groups and the top-level modules under src/ to four residues, none of them prose. All four were citation URLs under test in packages/fabrika-cli/src/decision — three in rule-verb.unit.test.ts and one in ruling-verb.unit.test.ts. `parseCitation` and `RULING_URL_RE` pin the github.com host in their own regexes, so a citation on any other host exercises nothing and the assertion stops testing what it names. Same class as the two build/ rows already carved out for it; the host pin itself is the portability defect, parked behind #8359. The ceiling moved 4 to 7 when `build resume-child` gained the same `--cites` arm and its battery in packages/fabrika-cli/src/build/resume-child-verb.unit.test.ts had to cover it: one URL the run admits, one naming another repository and one naming another issue, which are the two bindings `parseCitation` enforces and cannot be asserted without a URL that reaches its regex. Identical class, identical clearing edge — the three leave with the other four on #8359.",
 			"paths": ["packages/fabrika-cli/src"]
 		}
 	}

--- a/portability-guard.config.json
+++ b/portability-guard.config.json
@@ -52,6 +52,10 @@
 		"packages/fabrika-cli/src/build/claim-verb.unit.test.ts": {
 			"ceiling": 3,
 			"why": "The three `--cites` values a claim is admitted on, bound to the same hosted citation grammar `parseCitation` pins; every other fixture URL in the file is either a placeholder host or an API endpoint the matcher does not reach. The pin itself is the portability defect, parked behind #8359."
+		},
+		"packages/fabrika-cli/src/build/resume-child-verb.unit.test.ts": {
+			"ceiling": 3,
+			"why": "The three `--cites` values `build resume-child` forwards to its claim step, bound to the same hosted citation grammar `parseCitation` pins in its own regex: one URL the run is admitted on, one naming another repository and one naming another issue. Those two bindings are what the fail-closed cases assert, and neither can be exercised by a URL the regex never reaches. Same class and same clearing edge as its two siblings above; the pin itself is the portability defect, parked behind #8359."
 		}
 	},
 	"unmigrated": {
@@ -146,8 +150,8 @@
 			]
 		},
 		"cli-tail": {
-			"ceiling": 7,
-			"why": "#8310 swept the remaining small groups and the top-level modules under src/ to four residues, none of them prose. All four were citation URLs under test in packages/fabrika-cli/src/decision — three in rule-verb.unit.test.ts and one in ruling-verb.unit.test.ts. `parseCitation` and `RULING_URL_RE` pin the github.com host in their own regexes, so a citation on any other host exercises nothing and the assertion stops testing what it names. Same class as the two build/ rows already carved out for it; the host pin itself is the portability defect, parked behind #8359. The ceiling moved 4 to 7 when `build resume-child` gained the same `--cites` arm and its battery in packages/fabrika-cli/src/build/resume-child-verb.unit.test.ts had to cover it: one URL the run admits, one naming another repository and one naming another issue, which are the two bindings `parseCitation` enforces and cannot be asserted without a URL that reaches its regex. Identical class, identical clearing edge — the three leave with the other four on #8359.",
+			"ceiling": 4,
+			"why": "#8310 swept the remaining small groups and the top-level modules under src/ to four residues, none of them prose. All four are citation URLs under test in packages/fabrika-cli/src/decision — three in rule-verb.unit.test.ts and one in ruling-verb.unit.test.ts. `parseCitation` and `RULING_URL_RE` pin the github.com host in their own regexes, so a citation on any other host exercises nothing and the assertion stops testing what it names. Same class as the two build/ rows already carved out for it; the host pin itself is the portability defect, parked behind #8359.",
 			"paths": ["packages/fabrika-cli/src"]
 		}
 	}


### PR DESCRIPTION
`fabrika build resume-child` is the one sanctioned way into an epic child's standing-`FAIL` repair, but it hardcoded `cites: null` on the `build claim` step it wraps. A decision-typed child that had been ruled on, built, and then failed review was therefore unrepairable through it: the claim's type axis refused on exit `30` naming the `--cites` remedy, and the wrapper had no flag to carry one. The only route left was hand-assembling the five ordered steps — the ordering hazard the wrapper was built to remove.

`resume-child` now takes `--cites <url>` and forwards it, unchanged, to its claim step and to nothing else. `build claim` already binds the URL to this repository and this issue and opens the decision arm with it, so no judgment moved into the wrapper: an omitted citation on a decision is still `30`, a malformed or foreign URL is still `build claim`'s own `1` with its own words, and a citation admits no other type. A `--token` continuation needs no citation, because that arm answers off the standing marker before admission re-runs.

The battery in `resume-child-verb.unit.test.ts` covers the ruled-decision success path through the armed proof, the uncited `30`, the three fail-closed URL cases, an epic still refused with a citation in hand, an ordinary bug child unchanged with and without one, and the token-only continuation. Each fail-closed case asserts no marker was posted and no shell call ran at all, so no branch is renamed or checked out before a claim wins.

The flag's grammar landed on all six surfaces: the CLI help string, the contract's invocation line, inputs table, step-1 note, exit table and worked examples, the `SKILL.md` repair passage, the verb-reference row, and the module and options docblocks.

The test file's three host-pinned citation URLs are a permanent per-file residue, so they carry their own `exempt` row in `portability-guard.config.json` at `ceiling: 3` — the same bucket and the same `#8359` clearing edge its two siblings `scope-admission.unit.test.ts` and `claim-verb.unit.test.ts` already use. `unmigrated.cli-tail` stays at its landed ceiling of `4` with its original `why`: that bucket is the sweep floor a ratchet pays down, and its ceiling has to equal the unit's count, so a raise would spend the ratchet rather than record a reasoned exception (`packages/fabrika-cli/src/guard/portability.ts:276-279`, and the config's own `$comment`). An `exempt` row takes the file out of its group's count entirely (`portability.ts:303-304`), so the guard stays green at `4` without a raise.

Reviewer: start at the claim call in `resume-child-verb.ts`, then the new `describe` block at the end of its test file.

Fixes #7650

## Deviations

None.
