### PR TITLE
fix: Pattern anchor refuses workspaces with named catalogs

### DIFF
--- a/claude-plugins/fabrika/skills/write-pattern/contract.md
+++ b/claude-plugins/fabrika/skills/write-pattern/contract.md
@@ -478,7 +478,7 @@ fabrika pattern anchor worker-queue-retry [--dir <path>] [--manifest <path>] [--
 |---|---|---|---|---|
 | `<slug>` | positional string | yes | — | the doc's basename without `.md` |
 | `--dir` | string | no | `.patterns` | the directory the doc lives in |
-| `--manifest` | string | no | `pnpm-workspace.yaml` | the workspace manifest whose `catalog:` map holds the live pins |
+| `--manifest` | string | no | `pnpm-workspace.yaml` | the workspace manifest whose default and named catalog maps hold the live pins |
 | `--base` | string | no | `origin/main` | the base ref to fetch and read both the doc and the manifest from |
 | `--json` | boolean | no | `false` | emit the result as one JSON object instead of the line grammar |
 
@@ -507,16 +507,16 @@ fabrika pattern anchor worker-queue-retry [--dir <path>] [--manifest <path>] [--
    yields `@nkzw/fate` and `1.3.1`, where a first-`@` split would yield an empty package name. A token
    with no `@`, or whose split yields an empty half, is reported `malformed` and counted, never
    guessed at.
-3. **Resolve the pin.** Look `<package>` up as a key of the manifest's top-level `catalog:` map, read
-   as a block map of scalar pins. A key that is absent is `unpinned`.
+3. **Resolve the pin.** Read the manifest as strict YAML. Look up each declared package across
+   the default `catalog:` and every named map under `catalogs:`. Block and flow maps are
+   supported; package names and pins must be non-empty strings. An absent package is `unpinned`.
+   Equal pins across maps count as one. Conflicting pins for a declared package refuse at exit
+   `11`, naming the package and versions. A conflict for an unrelated package does not prevent
+   an answer. Declarations have no consumer scope, so the reader never chooses one conflicting pin.
 
-   **A catalog that is there and could not be read is exit `11`, never `unpinned`.** Three shapes are
-   outside what this reader comprehends — a flow map (`catalog: {…}`), a nested sub-map under a key,
-   and a named-catalog `catalogs:` block — and each of them parses as YAML, so none can be told apart
-   from a real read by parse success alone. Answering anyway produced two confident wrong answers:
-   the flow map and `catalogs:` both read as *no catalog at all* (`unpinned` for every declaration),
-   and the sub-map pinned its key to the empty string, which compares unequal to every declared
-   version and reported `moved` against a pin nobody wrote. All three refuse instead.
+   Unreadable YAML or invalid catalog structure is exit `11`, even for an unanchored document.
+   Nested version objects, non-string pins and duplicate YAML keys cannot establish a version.
+   A readable manifest with named catalogs and no dependency declarations answers `unanchored`.
 4. **Compare.** `<version>` against the pinned value, **byte for byte**, with no semver
    interpretation. A doc's anchor records the version its author actually read; accepting a range
    would silently bless a version nobody checked, which is the whole failure the line exists to catch.
@@ -585,8 +585,8 @@ With `--json`, one object with keys `outcome`, `declared`, `moved`, `unpinned`, 
 | `pattern anchor: slug "<slug>" is not kebab-case (lowercase letters, digits and single hyphens).` | 1 | usage error |
 
 **A manifest that reads but whose catalog this verb could not read is UNKNOWN too** (exit `11`), for
-the same reason — including the three comprehensible-YAML shapes in step 3. A manifest that carries
-**no `catalog:` key at all** is the degrade path instead: every declaration reports `unpinned` at exit
+the same reason, including invalid catalog structures in step 3. A manifest that carries
+**neither `catalog:` nor `catalogs:`** is the degrade path instead: every declaration reports `unpinned` at exit
 `0` with the absence named on stderr, because a repo that pins nothing centrally is a fact about that
 repo rather than a failed read. The two are not interchangeable: the degrade line names an absence,
 so it is never printed for a manifest that does carry a catalog.
@@ -598,7 +598,7 @@ at all. Fusing them is the same defect the `7`/`11` split exists to prevent — 
 surface's degrade path: every declaration reports `unpinned` at exit `0`, with the absence named on
 stderr.
 
-**Scope** — every anchor declaration in the subject doc, resolved against the `catalog:` map of
+**Scope** — every anchor declaration in the subject doc, resolved against the default and named catalog maps of
 `--manifest` at the fetched `--base`. The scope line goes to stderr naming the base sha, the manifest
 path and the four counts.
 

--- a/claude-plugins/fabrika/skills/write-pattern/contract.md
+++ b/claude-plugins/fabrika/skills/write-pattern/contract.md
@@ -636,9 +636,8 @@ $ fabrika pattern anchor worker-queue-retry --json --dir packages/fabrika-cli/te
   because that choice belongs to the open anchor-model decision and is unruled.
 - The anchor model is an open control-plane decision. Matching the existing prose line is the
   conservative floor: it is falsifiable today and it commits nothing.
-- The byte-for-byte comparison is deliberate. Every dependency in this repo is pinned to one exact
-  version through the workspace catalog, so a range comparison would have nothing to buy and a real
-  failure mode to hide.
+- The anchor records the exact dependency version its author read. Byte-for-byte comparison
+  prevents accepting a different version whose source was never checked.
 
 ---
 

--- a/packages/fabrika-cli/src/pattern/anchor-verb.ts
+++ b/packages/fabrika-cli/src/pattern/anchor-verb.ts
@@ -5,10 +5,10 @@
  * A separate verb rather than a mode of `pattern drift` because the git half and the dependency half
  * go stale independently. **An unreadable manifest is UNKNOWN and never `unpinned`:** the two are one
  * keystroke apart in consequence — `unpinned` says the repo does not carry this dependency, and a
- * failed read says nothing at all. A manifest that is genuinely absent, or that carries no `catalog:`
- * key at all, is the degrade path instead: every declaration reports `unpinned` at exit `0` with the
+ * failed read says nothing at all. A manifest that is genuinely absent, or that carries neither `catalog:` nor `catalogs:`
+ * keys, is the degrade path instead: every declaration reports `unpinned` at exit `0` with the
  * absence named on stderr. A manifest that *does* carry a catalog this reader cannot comprehend is
- * UNKNOWN, never that degrade path — see `parseCatalog`.
+ * UNKNOWN, never that degrade path. Conflicting pins refuse only when the doc declares that package.
  */
 import {Effect, type FileSystem, Result} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -156,14 +156,15 @@ export const runAnchor = (
 					`pattern anchor: cannot read ${manifest} at ${base}: ${manifestText.reason} — every pin is UNKNOWN, never "unpinned".`,
 				);
 			}
-			const parsed = parseCatalog(manifestText.value);
+			const parsed = parseCatalog(manifestText.value, declarationLinesIn(text.value));
 			if (parsed._tag === "Unparseable") {
 				return refuse(
 					PRECONDITION_UNKNOWN,
 					`pattern anchor: cannot read the catalog in ${manifest} at ${base}: ${parsed.reason} — every pin is UNKNOWN, never "unpinned".`,
 				);
 			}
-			if (parsed.catalog === null) degraded = `${manifest} at ${sha} carries no catalog: map`;
+			if (parsed.catalog === null)
+				degraded = `${manifest} at ${sha} carries no catalog: or catalogs: map`;
 			else catalog = parsed.catalog;
 		}
 

--- a/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
@@ -108,9 +108,6 @@ describe("runAnchor", () => {
 		expect(out.stderr.at(-1)).toContain("Tabs");
 	});
 
-	// The three unreadable catalog shapes, at the exit code a caller actually reads. Each parses as
-	// YAML and each carries a catalog the reader does not comprehend, so the verb refuses instead of
-	// answering — and in particular never claims the manifest "carries no catalog: or catalogs: map".
 	const manifest = (yaml: string): Script => [[/^git show \w+:\S+\.yaml$/, okOut(yaml)]];
 
 	it("reads flow and named-only maps through the command", async () => {

--- a/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
@@ -105,35 +105,69 @@ describe("runAnchor", () => {
 	it("refuses a manifest that does not parse as YAML", async () => {
 		const out = await run([[/^git show \w+:\S+\.yaml$/, okOut("catalog:\n\tacme-queue: 4.2.0\n")]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stderr.at(-1)).toContain("indents with a tab");
+		expect(out.stderr.at(-1)).toContain("Tabs");
 	});
 
 	// The three unreadable catalog shapes, at the exit code a caller actually reads. Each parses as
 	// YAML and each carries a catalog the reader does not comprehend, so the verb refuses instead of
-	// answering — and in particular never claims the manifest "carries no catalog: map".
+	// answering — and in particular never claims the manifest "carries no catalog: or catalogs: map".
 	const manifest = (yaml: string): Script => [[/^git show \w+:\S+\.yaml$/, okOut(yaml)]];
 
-	it("refuses an inline flow map instead of answering `unpinned`", async () => {
-		const out = await run(manifest("catalog: {acme-queue: 4.2.0}\n"));
-		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stdout).toBe("");
-		expect(out.stderr.join("\n")).not.toContain("carries no catalog: map");
+	it("reads flow and named-only maps through the command", async () => {
+		for (const text of [
+			"catalog: {acme-queue: 4.2.0}\n",
+			"catalogs:\n  current: {acme-queue: 4.2.0}\n",
+		]) {
+			const out = await run(manifest(text));
+			expect(out.code).toBe(0);
+			expect(out.stdout).toContain("pkg\tacme-queue\t4.1.0\t4.2.0\tmoved");
+		}
 	});
-
-	it("refuses a nested sub-map instead of answering `moved` against an empty pin", async () => {
+	it("refuses a nested sub-map instead of answering moved", async () => {
 		const out = await run(manifest("catalog:\n  acme-queue:\n    version: 4.2.0\n"));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("pins no version");
 	});
-
-	it("refuses a named-catalog block instead of reading it as no catalog at all", async () => {
-		const out = await run(manifest("catalogs:\n  default:\n    acme-queue: 4.2.0\n"));
-		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stdout).toBe("");
-		expect(out.stderr.join("\n")).not.toContain("carries no catalog: map");
+	it("resolves unique pins despite unrelated conflicts in the current workspace shape", async () => {
+		const text =
+			"catalog: {acme-queue: 4.1.0, effect: 4.0.0-beta.92}\ncatalogs:\n  local: {effect: 4.0.0-rc.112, fzf: 0.5.2}\n";
+		const out = await run(manifest(text));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("pkg\tacme-queue\t4.1.0\t4.1.0\tmatched");
+		const plain = await run(manifest(text), {slug: "plain-doc"});
+		expect(plain.code).toBe(0);
+		expect(plain.stdout).toBe("anchor\tunanchored\t0\t0\t0\t0\n");
 	});
-
+	it("accepts equal pins but refuses conflicting declared pins", async () => {
+		expect.assertions(5);
+		for (const version of ["4.1.0", "4.2.0"]) {
+			const out = await run(
+				manifest(`catalog: {acme-queue: 4.1.0}\ncatalogs:\n  legacy: {acme-queue: ${version}}\n`),
+			);
+			if (version === "4.1.0") {
+				expect(out.code).toBe(0);
+				expect(out.stdout).toContain("pkg\tacme-queue\t4.1.0\t4.1.0\tmatched");
+			} else {
+				expect(out.code).toBe(PRECONDITION_UNKNOWN);
+				expect(out.stdout).toBe("");
+				expect(out.stderr.at(-1)).toContain(
+					"acme-queue has conflicting catalog pins: 4.1.0, 4.2.0",
+				);
+			}
+		}
+	});
+	it("keeps malformed declarations and invalid manifests distinct from unanchored", async () => {
+		const malformed = await run([
+			...manifest("catalogs: {local: {acme-queue: 4.1.0}}\n"),
+			[/^git show \w+:\S+\.md$/, okOut("> Derived from broken\n")],
+		]);
+		expect(malformed.code).toBe(0);
+		expect(malformed.stdout).toContain("anchor\tmalformed\t1\t0\t0\t1");
+		const invalid = await run(manifest("catalogs: []\n"), {slug: "plain-doc"});
+		expect(invalid.code).toBe(PRECONDITION_UNKNOWN);
+		expect(invalid.stdout).toBe("");
+	});
 	// The degrade path: a repo that pins nothing centrally is a fact about that repo, not a failure.
 	it("degrades to `unpinned` at exit 0 when the manifest is absent, and says so on stderr", async () => {
 		const out = await run([[/^git ls-tree --name-only \w+ -- \S+\.yaml$/, okOut("")]]);
@@ -146,7 +180,7 @@ describe("runAnchor", () => {
 		const out = await run([[/^git show \w+:\S+\.yaml$/, okOut("packages:\n  - packages/*\n")]]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe("anchor\tunpinned\t2\t0\t2\t0");
-		expect(out.stderr.join("\n")).toContain("carries no catalog: map");
+		expect(out.stderr.join("\n")).toContain("carries no catalog: or catalogs: map");
 	});
 
 	// `unborn` mirrors `pattern drift` deliberately: one tree state must not produce two verdicts.

--- a/packages/fabrika-cli/src/pattern/anchor.ts
+++ b/packages/fabrika-cli/src/pattern/anchor.ts
@@ -8,6 +8,7 @@
  * declares an anchor I could not parse"*, which is true and actionable — the same discipline
  * `./drift.ts` applies to an unresolved path.
  */
+import {isMap, isScalar, parseDocument} from "yaml";
 import {ANCHOR_DECLARATION, ANCHOR_PREFIX, splitAnchorToken} from "./doc.ts";
 
 export type DeclarationState = "matched" | "moved" | "unpinned" | "malformed";
@@ -37,76 +38,85 @@ export const declarationLinesIn = (text: string): ReadonlyArray<string> =>
 
 export type CatalogRead =
 	| {readonly _tag: "Ok"; readonly catalog: Readonly<Record<string, string>> | null}
-	/** The reader could not comprehend the manifest's catalog — UNKNOWN, never a pin and never `null`. */
 	| {readonly _tag: "Unparseable"; readonly reason: string};
 
-/** Enough of an offending line to find it, on one line and clamped. */
-const lineEcho = (line: string): string =>
-	line
-		.trim()
-		.replace(/[\t\n\r]+/g, " ")
-		.slice(0, 80);
-
-/**
- * The manifest's top-level `catalog:` map, as a block map of scalar pins.
- *
- * `catalog: null` is the **degrade** path, not a failure: a repo that pins nothing centrally is a
- * fact about that repo, so every declaration reports `unpinned` at exit `0`. Every other shape this
- * reader cannot comprehend — a flow map (`catalog: {…}`), a nested sub-map under a key, a
- * named-catalog `catalogs:` block — is UNKNOWN, **not** the degrade path: it is a map that is there
- * and was not read, so answering `unpinned` would be a confident wrong answer where the caller
- * deserves a refusal. The `7`/`11` split, applied to a file: a missing key is a verdict, a
- * document this reader could not read is a verdict about nothing.
- */
-export const parseCatalog = (text: string): CatalogRead => {
-	const lines = text.split("\n");
-	for (const [at, line] of lines.entries()) {
-		if (/^[ ]*\t/.test(line)) {
-			return {_tag: "Unparseable", reason: `line ${at + 1} indents with a tab, which YAML forbids`};
-		}
-	}
-	const named = lines.findIndex((line) => /^catalogs:/.test(line));
-	if (named !== -1) {
+/** Read all catalog maps; only a declared dependency's conflicting pins prevent its answer. */
+export const parseCatalog = (
+	text: string,
+	declarations: ReadonlyArray<string> = [],
+): CatalogRead => {
+	const doc = parseDocument(text, {strict: true});
+	if (doc.errors.length > 0) {
 		return {
 			_tag: "Unparseable",
-			reason: `line ${named + 1} opens a named-catalog "catalogs:" block, which this reader does not interpret`,
+			reason: doc.errors.map((error) => error.message.split("\n")[0]).join("; "),
 		};
 	}
-	const start = lines.findIndex((line) => /^catalog:/.test(line));
-	if (start === -1) return {_tag: "Ok", catalog: null};
-	const header = lines[start] ?? "";
-	if (!/^catalog:\s*(#.*)?$/.test(header)) {
-		return {
-			_tag: "Unparseable",
-			reason: `line ${start + 1} carries "catalog:" with inline content (\`${lineEcho(header)}\`), which this reader does not interpret`,
-		};
+	if (!isMap(doc.contents))
+		return {_tag: "Unparseable", reason: "workspace manifest must be a map"};
+	const pins = new Map<string, Set<string>>();
+	const readMap = (value: unknown, name: string): string | null => {
+		if (!isMap(value)) return `${name} must be a map of package names to string pins`;
+		for (const pair of value.items) {
+			if (!isScalar(pair.key) || typeof pair.key.value !== "string" || pair.key.value === "") {
+				return `${name} contains a non-string or empty package name`;
+			}
+			if (
+				!isScalar(pair.value) ||
+				typeof pair.value.value !== "string" ||
+				pair.value.value.trim() === ""
+			) {
+				return `${name}.${pair.key.value} pins no version string`;
+			}
+			const versions = pins.get(pair.key.value) ?? new Set<string>();
+			versions.add(pair.value.value);
+			pins.set(pair.key.value, versions);
+		}
+		return null;
+	};
+	const hasDefault = doc.contents.has("catalog");
+	const hasNamed = doc.contents.has("catalogs");
+	if (hasDefault) {
+		const reason = readMap(doc.contents.get("catalog", true), "catalog");
+		if (reason !== null) return {_tag: "Unparseable", reason};
 	}
-
-	const catalog: Record<string, string> = {};
-	for (let at = start + 1; at < lines.length; at += 1) {
-		const line = lines[at] ?? "";
-		if (line.trim() === "" || /^\s*#/.test(line)) continue;
-		if (!/^\s/.test(line)) break;
-		const m = /^\s+(.+?)\s*:\s*(.*?)\s*$/.exec(line);
-		if (m?.[1] === undefined || m[2] === undefined) {
+	if (hasNamed) {
+		const named = doc.contents.get("catalogs", true);
+		if (!isMap(named))
+			return {_tag: "Unparseable", reason: "catalogs must be a map of named catalogs"};
+		for (const pair of named.items) {
+			if (!isScalar(pair.key) || typeof pair.key.value !== "string" || pair.key.value === "") {
+				return {
+					_tag: "Unparseable",
+					reason: "catalogs contains a non-string or empty catalog name",
+				};
+			}
+			const reason = readMap(pair.value, `catalogs.${pair.key.value}`);
+			if (reason !== null) return {_tag: "Unparseable", reason};
+		}
+	}
+	for (const line of declarations) {
+		const token = ANCHOR_DECLARATION.exec(line)?.[1];
+		const split = token === undefined ? null : splitAnchorToken(token);
+		if (split === null) continue;
+		const versions = pins.get(split.pkg);
+		if (versions !== undefined && versions.size > 1) {
 			return {
 				_tag: "Unparseable",
-				reason: `line ${at + 1} sits under catalog: and is not a key/value pair`,
+				reason:
+					split.pkg +
+					" has conflicting catalog pins: " +
+					[...versions].join(", ") +
+					"; a dependency declaration needs one distinct pin",
 			};
 		}
-		const version = m[2].replace(/^['"]|['"]$/g, "");
-		// An empty value heads a nested sub-map, whose children then land as sibling keys; a `{`/`[`
-		// value is a flow collection. Either way the key's pin is not this line, and storing "" would
-		// compare unequal to every declared version and report `moved` against a pin nobody wrote.
-		if (version === "" || version.startsWith("{") || version.startsWith("[")) {
-			return {
-				_tag: "Unparseable",
-				reason: `line ${at + 1} sits under catalog: and pins no version (\`${lineEcho(line)}\`)`,
-			};
-		}
-		catalog[m[1].replace(/^['"]|['"]$/g, "")] = version;
 	}
-	return {_tag: "Ok", catalog};
+	const catalog = Object.fromEntries(
+		[...pins].flatMap(([pkg, versions]) =>
+			versions.size === 1 ? [...versions].map((version) => [pkg, version]) : [],
+		),
+	);
+	return {_tag: "Ok", catalog: hasDefault || hasNamed ? catalog : null};
 };
 
 /**

--- a/packages/fabrika-cli/src/pattern/anchor.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/anchor.unit.test.ts
@@ -58,40 +58,49 @@ onlyBuiltDependencies:
 		expect(parseCatalog("catalog:\n  - acme-queue\n")._tag).toBe("Unparseable");
 	});
 
-	// The three unreadable shapes: each one parses as YAML, none of them is read, and answering
-	// `catalog: null` or an empty-string pin would be a confident wrong answer rather than a refusal.
-	it("refuses an inline flow map rather than reading it as no catalog at all", () => {
-		expect(parseCatalog("catalog: {acme-queue: 4.2.0}\n")).toMatchObject({
-			_tag: "Unparseable",
-			reason: expect.stringContaining("inline content"),
+	it("reads valid flow maps", () => {
+		expect(parseCatalog("catalog: {acme-queue: 4.2.0}\n")).toEqual({
+			_tag: "Ok",
+			catalog: {"acme-queue": "4.2.0"},
 		});
 	});
-
-	it("refuses a nested sub-map rather than pinning the key to an empty string", () => {
-		expect(parseCatalog("catalog:\n  acme-queue:\n    version: 4.2.0\n")).toMatchObject({
-			_tag: "Unparseable",
-			reason: expect.stringContaining("pins no version"),
-		});
+	it.each([
+		"catalog:\n  acme-queue:\n    version: 4.2.0\n",
+		"catalogs: []\n",
+		"catalogs:\n  legacy: null\n",
+		"catalog: {acme-queue: 42}\n",
+		"catalog: {acme-queue: ''}\n",
+		"catalog: {acme-queue: 4.2.0, acme-queue: 4.1.0}\n",
+		"catalog: {acme-queue: 4.2.0}\ncatalog: {}\n",
+		"catalog: {}\nbroken: [\n",
+		"[]\n",
+	])("refuses invalid manifest or catalog shape %s", (text) => {
+		expect(parseCatalog(text)._tag).toBe("Unparseable");
 	});
-
-	it("refuses an entry whose value is a flow collection", () => {
-		expect(parseCatalog("catalog:\n  acme-queue: {version: 4.2.0}\n")._tag).toBe("Unparseable");
-	});
-
-	it("refuses a named-catalog block rather than reading it as no catalog at all", () => {
-		expect(parseCatalog("catalogs:\n  default:\n    acme-queue: 4.2.0\n")).toMatchObject({
-			_tag: "Unparseable",
-			reason: expect.stringContaining("catalogs:"),
-		});
-	});
-
-	// Reading only the flat half of a manifest that also names catalogs would report `unpinned` for
-	// every package pinned through the named half — the same confident wrong answer, one level in.
-	it("refuses a manifest that carries both a flat catalog and a named-catalog block", () => {
+	it("reads named-only maps and equal duplicate pins", () => {
 		expect(
-			parseCatalog("catalog:\n  acme-queue: 4.2.0\n\ncatalogs:\n  legacy:\n    acme-queue: 3.0.0\n")
-				._tag,
-		).toBe("Unparseable");
+			parseCatalog("catalogs:\n  current: {acme-queue: 4.2.0}\n  other: {acme-queue: 4.2.0}\n"),
+		).toEqual({_tag: "Ok", catalog: {"acme-queue": "4.2.0"}});
+	});
+	it("reads default and unrelated named catalog pins", () => {
+		expect(
+			parseCatalog("catalog: {alchemy: 2.0.0-beta.59}\ncatalogs:\n  local: {fzf: 0.5.2}\n"),
+		).toEqual({_tag: "Ok", catalog: {alchemy: "2.0.0-beta.59", fzf: "0.5.2"}});
+	});
+	it("refuses only a declared dependency's conflicting pins", () => {
+		const text =
+			"catalog: {effect: 4.0.0-beta.92, alchemy: 2.0.0-beta.59}\ncatalogs:\n  local: {effect: 4.0.0-rc.112, fzf: 0.5.2}\n";
+		expect(
+			parseCatalog(text, ["> Derived from `effect@4.0.0-beta.92` — re-verify on pin bump."]),
+		).toMatchObject({
+			_tag: "Unparseable",
+			reason: expect.stringContaining(
+				"effect has conflicting catalog pins: 4.0.0-beta.92, 4.0.0-rc.112",
+			),
+		});
+		expect(
+			parseCatalog(text, ["> Derived from `alchemy@2.0.0-beta.59` — re-verify on pin bump."]),
+		).toEqual({_tag: "Ok", catalog: {alchemy: "2.0.0-beta.59", fzf: "0.5.2"}});
 	});
 });
 

--- a/packages/fabrika-cli/src/pattern/command.ts
+++ b/packages/fabrika-cli/src/pattern/command.ts
@@ -87,7 +87,7 @@ const anchor = leafCommand(
 ).pipe(
 	Command.withShortDescription("Whether the dependency version a doc declares still matches."),
 	Command.withDescription(
-		'Whether the dependency version a doc declares still matches what the workspace pins, compared byte for byte with no semver interpretation. Prints `anchor <matched|moved|malformed|unpinned|unanchored|unborn> <declared> <moved> <unpinned> <malformed>` then one `pkg` line per declaration — every outcome at exit 0. A line that claims an anchor and does not parse is `malformed`, never absent. Exits 11 (the base could not be fetched, or the doc or manifest could not be read — every pin is UNKNOWN, never "unpinned"), 12 (no doc for the slug). Example: fabrika pattern anchor worker-queue-retry',
+		'Whether the dependency version a doc declares still matches what the workspace pins, compared byte for byte across default and named catalogs. A declared dependency with conflicting pins refuses at exit 11; unrelated conflicts do not block an answer. Prints `anchor <matched|moved|malformed|unpinned|unanchored|unborn> <declared> <moved> <unpinned> <malformed>` then one `pkg` line per declaration — every outcome at exit 0. A line that claims an anchor and does not parse is `malformed`, never absent. Exits 11 (the base could not be fetched, or the doc or manifest could not be read — every pin is UNKNOWN, never "unpinned"), 12 (no doc for the slug). Example: fabrika pattern anchor worker-queue-retry',
 	),
 );
 


### PR DESCRIPTION
Pattern version checks now read default and named workspace catalogs. A uniquely pinned dependency resolves even when an unrelated dependency has conflicting versions; conflicting pins for the declared dependency still stop the check with the package and versions named.

Fixes #8909

Validated with 180 pattern tests and Fabrika code/prose checks, including affected typechecks, lint and repository guards. The actual Alchemy pattern command changed from exit 11 to a matched answer against the same main commit. The reader uses the existing `yaml` dependency's strict document parser, following the local skill-lint reader.

## Deviations

- **Pre-existing test or fixture changed**. **Said:** existing tests required rejecting all named catalogs and valid flow maps. **Did:** replaced those assertions with supported-map outcomes and added conflicting-pin and malformed-input regressions; updated the tab-error assertion to the YAML parser's diagnostic. **Why:** blanket rejection was the reported defect, and strict YAML can read valid flow maps. **Disposition:** disclosed for review; invalid structures and ambiguous declared pins retain refusal coverage.
