### PR TITLE
fix: Pi reviewer timeout interrupts Fabrika's bounded CI wait

### DIFF
--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -245,6 +245,14 @@ the rollup. Each token routes on its own:
 The refusals reach you unchanged and on the first read — `--wait` polls a `pending` and nothing else,
 so a `16` head, a repo with no producer, or a floor waiting on you never burns the budget.
 
+**Give the call a caller-side deadline above `--budget-seconds`, or the budget decides nothing.**
+The verb owns the loop only for as long as its process lives: a shell that wraps this call in a
+timeout shorter than the budget kills the CLI mid-poll, so none of the four `settle` tokens comes
+back and the class ends `UNKNOWN` with the head unread. One reviewer shell did exactly that with a
+120-second timeout over the 600-second default, and was killed at 120s with CI still running. Use
+**1800 seconds**, and raise it again whenever you raise `--budget-seconds`. It is a practical value with headroom for the `gh`
+reads, not a guaranteed CLI maximum — the verb promises only that it stops polling at its budget.
+
 **On a `governance: required` diff, fire §6's governance skill before you wait on CI.** The floor
 check-run at the head cannot go green until a governance verdict binds there, and you are the shell
 that owes it — so a `--wait` run first is a wait on yourself. The verb names that rather than

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -190,7 +190,7 @@ green as this PR's. The code class's execution evidence is the structural CI-at-
 incomplete enumerations:
 
 ```bash
-fabrika review ci $pr_number --sha 03135b91 --wait
+fabrika review ci $pr_number --sha 03135b91 --wait --budget-seconds 480
 ```
 
 **Its `green` now carries gate coverage, and the absence of coverage is its own answer.** A head
@@ -249,9 +249,19 @@ so a `16` head, a repo with no producer, or a floor waiting on you never burns t
 The verb owns the loop only for as long as its process lives: a shell that wraps this call in a
 timeout shorter than the budget kills the CLI mid-poll, so none of the four `settle` tokens comes
 back and the class ends `UNKNOWN` with the head unread. One reviewer shell did exactly that with a
-120-second timeout over the 600-second default, and was killed at 120s with CI still running. Use
-**1800 seconds**, and raise it again whenever you raise `--budget-seconds`. It is a practical value with headroom for the `gh`
-reads, not a guaranteed CLI maximum — the verb promises only that it stops polling at its budget.
+120-second timeout over the 600-second default, and was killed at 120s with CI still running.
+
+**The deadline is the Bash tool's own `timeout`, in milliseconds, and it has a ceiling you cannot
+ask past.** That ceiling is `600000` ms, raised only when the environment sets `BASH_MAX_TIMEOUT_MS`
+above it; a larger request is neither honoured nor refused, it is silently reduced to the ceiling.
+So asking for half an hour on a stock shell buys 600 seconds — exactly the default budget, not above
+it — and leaves the same race the paragraph above exists to end, now behind a number that reads like
+headroom. Raising the deadline alone cannot work, so **pair the two numbers**: `timeout: 600000` on
+the tool call against the `--budget-seconds 480` the block above already carries, which puts the
+deadline two minutes clear of the budget for the `gh` reads to land inside. That is a practical
+pairing, not a guaranteed CLI maximum — the verb promises only that it stops polling at its budget —
+and the rule that generalises is the inequality, not either number: a budget raised past the ceiling
+needs `BASH_MAX_TIMEOUT_MS` raised with it, or it is a budget nothing can wait out.
 
 **On a `governance: required` diff, fire §6's governance skill before you wait on CI.** The floor
 check-run at the head cannot go green until a governance verdict binds there, and you are the shell

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -597,9 +597,14 @@ fabrika review ci 4321 [--sha <head>] [--wait] [--budget-seconds <n>] [--cadence
 
 **A `--wait` call must be invoked with a caller-side timeout above `--budget-seconds`.** The budget
 bounds the verb, not the process around it: a shell timeout below the budget kills the CLI mid-poll,
-no `settle` token is printed, and the caller has an `UNKNOWN` instead of an answer. Against the `600`
-default, use `1800` seconds — headroom for the `gh` reads, and a practical value rather than a
-guaranteed CLI maximum, so a raised budget needs a raised caller deadline too.
+no `settle` token is printed, and the caller has an `UNKNOWN` instead of an answer. In an agent shell
+that deadline is the Bash tool's `timeout`, whose ceiling is `600000` ms unless the environment sets
+`BASH_MAX_TIMEOUT_MS` above it — a larger request is silently clamped to the ceiling rather than
+refused, so no deadline past it can be asked for. That leaves the `600` default budget with no
+headroom on either side: pair `timeout: 600000` with `--budget-seconds 480` instead, which keeps the
+deadline strictly above the budget with room for the `gh` reads. A practical pairing, not a
+guaranteed CLI maximum, and a budget raised past the ceiling needs `BASH_MAX_TIMEOUT_MS` raised
+with it.
 
 **Output** — machine channel. Under `--wait`, a first line
 `settle\t<settled|budget-exhausted|head-moved|governance-owed|governance-stale>`; without it that

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -595,6 +595,12 @@ fabrika review ci 4321 [--sha <head>] [--wait] [--budget-seconds <n>] [--cadence
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
+**A `--wait` call must be invoked with a caller-side timeout above `--budget-seconds`.** The budget
+bounds the verb, not the process around it: a shell timeout below the budget kills the CLI mid-poll,
+no `settle` token is printed, and the caller has an `UNKNOWN` instead of an answer. Against the `600`
+default, use `1800` seconds — headroom for the `gh` reads, and a practical value rather than a
+guaranteed CLI maximum, so a raised budget needs a raised caller deadline too.
+
 **Output** — machine channel. Under `--wait`, a first line
 `settle\t<settled|budget-exhausted|head-moved|governance-owed|governance-stale>`; without it that
 line is absent. Then


### PR DESCRIPTION
`fabrika review ci <pr> --wait` bounds its own loop at `--budget-seconds` (default 600), but nothing
told the caller its process deadline has to sit above that. A reviewer shell put a 120-second bash
timeout on the call, the CLI was killed at 120s, none of the four `settle` tokens came back, and the
shell exited zero with the verdict `UNKNOWN`.

This states the floor where the skill already promises one call is enough, and states it as a pairing
rather than a number, because the caller-side deadline has a ceiling it cannot be asked past:

- `claude-plugins/fabrika/skills/review/SKILL.md`, CI wait section: a `--wait` call must carry a
  caller-side timeout above `--budget-seconds`; that deadline is the Bash tool's own `timeout`, whose
  ceiling is `600000` ms unless `BASH_MAX_TIMEOUT_MS` raises it, and a larger request is silently
  reduced to the ceiling rather than refused. So the prescription is `timeout: 600000` against
  `--budget-seconds 480` — a practical pairing, not a guaranteed CLI maximum — and the rule that
  generalises is the inequality, not either number.
- The section's own `review ci` call block now carries `--budget-seconds 480`, so the budget half of
  the pairing is at the call site a reader copies.
- `claude-plugins/fabrika/skills/review/contract.md`: the same bound beside the `--budget-seconds`
  flag row, which is where a reader looks for the flag's limit.

The ceiling is read off the installed harness rather than assumed: the requested timeout is resolved
by `Math.min(requested, max, …)` where `max` falls back to the constant `600000` when
`BASH_MAX_TIMEOUT_MS` is unset, and a bitten clamp emits a `timeout_clamped` notice, not an error.
That is what made the previous text's `1800` unreachable — it resolved to 600 seconds, equal to the
default budget rather than above it.

The pi bundle carries no committed copy — `packages/fabrika-pi/dist/` is gitignored and produced at
release time by `packages/fabrika-pi/scripts/sync-bundle.mjs` from the authored plugin sources, so
the authored tree is the only home and there is nothing hand-edited to diverge.

`pnpm lint` passes and `fabrika build check --surface prose` is green with nothing unvalidated; no
TypeScript changed in this round.

Fixes #8619

## Deviations

- **Declined guidance** — **Said:** the issue's observation section cites PR #8600 as the production
  sighting, and my first draft named it in the SKILL.md text. **Did:** kept the incident but dropped
  the number and URL, so the sentence reads "one reviewer shell did exactly that with a 120-second
  timeout over the 600-second default". **Why:** `guard portability-guard check` reds on a repo-specific
  issue number, URL or repo name inside the shipped fabrika corpus, and the `plugin-tail` row is
  already over its ceiling. **Disposition:** stated here; the citation lives on the issue and in this
  PR body, which are repo-local surfaces.
- **Declined guidance** — **Said:** the review's second note suggests moving the value to a single
  home, with `SKILL.md` carrying the obligation and pointing at the contract row. **Did:** kept both
  concrete numbers in both files. **Why:** acceptance criteria 1, 3 and 6 each bind a file to name
  the value and the mechanism itself, so a pointer would leave one of them unmet; the drift the note
  worried about is answered instead by making the rule an inequality between the two flags, which no
  future raise invalidates. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue names the CI-wait prose and the contract flag row.
  **Did:** also added `--budget-seconds 480` to the section's `review ci` command block. **Why:** the
  prescription is a pairing, and with the block still taking the `600` default the reader who copies
  it gets the half that fails; criterion 6 asks that the prescribed pairing leave the deadline
  strictly above the budget, which the call site has to carry. **Disposition:** stated here.
