### PR TITLE
chore: Epic #8810's four .fabrika.jsonc axes all ship off, and nothing tracks declaring them

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -32,6 +32,30 @@
 	// raising this line is the only way past.
 	"laneConcurrencyCap": 2,
 
+	// The four epic-run axes #8810 shipped, each defaulting to the pre-epic behaviour so an
+	// undeclaring repo saw no change (ADRs 0376/0377). Phoenix turns all four on, founder-ruled
+	// 2026-09-10 on #8936 (https://github.com/kamp-us/phoenix/issues/8936#issuecomment-5624531920):
+	// no precondition per key, no drain wait. `machineryLaps.onEmit` is read at emission, so lanes
+	// already on disk keep the old arithmetic until they finish and two rule sets run side by side
+	// until then — accepted in that ruling.
+	//
+	// `parkCause.driverRouted` is `refuse`, which is also its shipped default: the ruling declares
+	// the value rather than flipping it, so this repo cannot drift if the default ever moves.
+	"assemblyRefresh": {
+		"onReview": "on",
+		"onDispatch": "on"
+	},
+	"assemblyReplay": {
+		"onCollision": "on"
+	},
+	"machineryLaps": {
+		"onEmit": "on"
+	},
+	"parkCause": {
+		"uncaused": "refuse",
+		"driverRouted": "refuse"
+	},
+
 	// Who may declare a campaign or flip its lifecycle state (`fabrika campaign open` / `campaign
 	// state`). It narrows the repo's collaborator ACL and never replaces it: an entry here still
 	// needs `write` or above on the repo (ADR 0294). Founder-declared 2026-08-20 on #6811 — the


### PR DESCRIPTION
Fixes #8936

Phoenix now declares the four epic-run axes epic #8810 shipped, all four on, in one commit against `main`:

| Key | Declared |
|---|---|
| `assemblyRefresh` | `{onReview: "on", onDispatch: "on"}` |
| `assemblyReplay` | `{onCollision: "on"}` |
| `machineryLaps` | `{onEmit: "on"}` |
| `parkCause` | `{uncaused: "refuse", driverRouted: "refuse"}` |

Transcription of the founder ruling of 2026-09-10 PT, cited in the file's own comment block so it lands in the diff: https://github.com/kamp-us/phoenix/issues/8936#issuecomment-5624531920 — "yes, turn all four on". No precondition per key, no drain wait: `machineryLaps.onEmit` is read at emission, so lanes already on disk keep the old arithmetic until they finish and two rule sets run side by side until then. That is accepted in the ruling.

`parkCause.driverRouted` is `refuse`, which is also its shipped default. The ruling declares the value rather than flipping it, so the repo cannot drift if the default ever moves.

The four are inserted after `laneConcurrencyCap`, which is untouched and unmoved — the diff is 24 insertions and no deletions.

What a reviewer should look at first: the four values against the ruling comment, and that `laneConcurrencyCap` still reads `2`.

Verification on this branch:

- `fabrika status settings` — all four print `declared` with exactly the ruled values, readout `resolved`, exit 0. No exit 18.
- `fabrika config schema` — `schema agrees 25`, so the committed `.fabrika.schema.json` already covers these keys and needs no regeneration.
- `biome check .fabrika.jsonc` — clean.

## Deviations

- **Guard or gate bypassed** — **Said:** the build loop validates the diff with `fabrika build check`. **Did:** `build check` refuses this diff on exit `22` under every surface, so the change was validated with `fabrika status settings`, `fabrika config schema` and `biome check` instead. **Why:** `.fabrika.jsonc` falls in the contract's named "unvalidatable" class — no surface's validators open a `.jsonc` file — and the contract's remedy (extend a validator) is a source change the acceptance criteria forbid this diff. **Disposition:** stated here and filed as a follow-up.
