### PR TITLE
roadmap: Epic lanes campaign (#49) flips to done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,7 +115,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | fabrika everywhere | #47 | done |
 | Geçit product push | #24 | active |
 | Lane integrity | #48 | active |
-| Epic lanes | #49 | active |
+| Epic lanes | #49 | done |
 | Diátaxis README passes | #50 | done |
 | Tuval | #51 | done |
 | Tuval first slice | #52 | done |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,7 @@ flowchart TD
 		camp_fabrika_everywhere["fabrika everywhere"]:::done
 		camp_ge_it_product_push["Geçit product push"]:::active
 		camp_lane_integrity["Lane integrity"]:::active
-		camp_epic_lanes["Epic lanes"]:::active
+		camp_epic_lanes["Epic lanes"]:::done
 		camp_di_taxis_readme_passes["Diátaxis README passes"]:::done
 		camp_tuval["Tuval"]:::done
 		camp_tuval_first_slice["Tuval first slice"]:::done


### PR DESCRIPTION
Milestone 49 (Epic lanes) has 70 closed, 0 open. The campaign row in ROADMAP.md moves from active to done, past the founder's campaign-approve marker: https://github.com/kamp-us/phoenix/issues/6812#issuecomment-5625091707

🤖 Generated with [Claude Code](https://claude.com/claude-code)