### PR TITLE
fix: A shell whose lane report loses the events.lock race twice drops its terminal entirely

### DIFF
--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -106,6 +106,11 @@ export interface FakeFsOptions {
 	/**
 	 * Directory paths whose creation fails `AlreadyExists` even when nothing is there — modeling a
 	 * lock another writer holds, so the losing side of an append race is testable on demand.
+	 *
+	 * A held lock is *removable*: once something removes the path, creating it succeeds again, and it
+	 * `stat`s as a directory meanwhile (give it an age through {@link FakeFsOptions.mtimes}). A fake
+	 * that failed forever could not tell a steal that lands from one that changes nothing — which is
+	 * the whole difference between a stale lock a waiter recovers from and one that bricks the lane.
 	 */
 	readonly mkdirExisting?: ReadonlyArray<string>;
 	/**
@@ -127,7 +132,8 @@ export const fakeFs = (options: FakeFsOptions): FakeFs => {
 	const dirs: Record<string, ReadonlyArray<string> | null> = {...options.dirs};
 	const files: Record<string, string | null> = {...options.files};
 	const written = new Map<string, string>();
-	const directories = new Set(options.directories ?? []);
+	const directories = new Set([...(options.directories ?? []), ...(options.mkdirExisting ?? [])]);
+	const held = new Set(options.mkdirExisting ?? []);
 	const decoder = new TextDecoder();
 	const layer = Layer.merge(
 		FileSystem.layerNoop({
@@ -166,7 +172,7 @@ export const fakeFs = (options: FakeFsOptions): FakeFs => {
 				if (options.mkdirMissingParent?.includes(path) === true) {
 					return notFound("makeDirectory", path);
 				}
-				if (options.mkdirExisting?.includes(path) === true) {
+				if (held.has(path)) {
 					return Effect.fail(
 						PlatformError.systemError({
 							_tag: "AlreadyExists",
@@ -228,6 +234,7 @@ export const fakeFs = (options: FakeFsOptions): FakeFs => {
 				if (options.unremovable?.includes(path) === true) return denied("remove", path);
 				if (options.survivesRemoval?.includes(path) === true) return Effect.void;
 				directories.delete(path);
+				held.delete(path);
 				for (const key of Object.keys(files)) {
 					if (key === path || key.startsWith(`${path}/`)) delete files[key];
 				}

--- a/packages/fabrika-cli/src/lane/append-lock.ts
+++ b/packages/fabrika-cli/src/lane/append-lock.ts
@@ -20,6 +20,18 @@
  * otherwise leave the sidecar forever, so a lock whose directory mtime is older than
  * {@link STALE_LOCK_MS} is stolen on sight. Anything newer is presumed alive; waiting is the honest
  * answer.
+ *
+ * **The two durations are one setting, which is why only one of them is written down.** A waiter
+ * gives up at its budget and a lock only becomes stealable at the stale horizon, so a budget
+ * shorter than the horizon makes the horizon unreachable: every writer arriving inside the
+ * difference refuses {@link CONCURRENT_WRITE} against a lock nobody holds, and nothing waits the
+ * window out. That gap shipped — a 5s budget against a 60s horizon left an orphaned lock
+ * un-stealable for 55 seconds, and a shell lost its terminal to it twice seconds apart. So the
+ * horizon is the knob and the default budget is **derived** from it: raise or lower
+ * {@link STALE_LOCK_MS} and the budget moves with it, because the one thing a reader must not be
+ * able to do is tune one of them alone.
+ * `FABRIKA_LANE_LOCK_BUDGET_MS` still overrides the budget on purpose — a caller asking to refuse
+ * fast is asking not to reach the horizon at all.
  */
 import {Effect, type FileSystem, Option, type Path, Result} from "effect";
 import {CONCURRENT_WRITE} from "./codes.ts";
@@ -28,8 +40,28 @@ import {WORKFLOW_FILE} from "./store.ts";
 /** The sidecar directory a holding writer creates inside the lane directory. */
 export const LOCK_DIR_NAME = "events.lock";
 
-/** How long a writer waits for a held lock before refusing rather than writing blind. */
-const DEFAULT_LOCK_BUDGET_MS = 5_000;
+/**
+ * A held lock older than this is presumed crashed, not slow, and is stolen.
+ *
+ * It is a margin over how long a legitimate holder can take, and that is bounded: everything inside
+ * the lock is local IO — load, fold, validate, append — because each verb's board read runs before
+ * it. Ten seconds is two orders of magnitude over a hold that measures in milliseconds, which is
+ * the honest reading of "this process is gone", while staying inside a wait a shell can afford.
+ */
+const STALE_LOCK_MS = 10_000;
+
+/** Poll cadence while waiting for a held lock. */
+const POLL_MS = 50;
+
+/**
+ * How long a writer waits for a held lock before refusing rather than writing blind — the stale
+ * horizon plus enough polls to notice and steal, never a second number to keep in step by hand.
+ *
+ * The grace matters because the two clocks start apart: a waiter arriving the instant a lock was
+ * created reaches the horizon a full {@link STALE_LOCK_MS} later and still needs a poll to act on
+ * it. A budget equal to the horizon would expire in that gap.
+ */
+const DEFAULT_LOCK_BUDGET_MS = STALE_LOCK_MS + 20 * POLL_MS;
 
 /**
  * The budget is an operations surface, not just a constant: a caller that would rather refuse fast
@@ -40,12 +72,6 @@ const lockBudgetMs = (): number => {
 	const parsed = raw === undefined ? Number.NaN : Number(raw);
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LOCK_BUDGET_MS;
 };
-
-/** A held lock older than this is presumed crashed, not slow, and is stolen. */
-const STALE_LOCK_MS = 60_000;
-
-/** Poll cadence while waiting for a held lock. */
-const POLL_MS = 50;
 
 export interface LockRefusal {
 	readonly _tag: "Locked";
@@ -74,17 +100,30 @@ const acquireOnce = (
 		return made.failure.reason._tag === "NotFound" ? "absent" : "held";
 	});
 
+const removeLock = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<void, never> =>
+	Effect.ignore(fs.remove(lockDir, {recursive: true}));
+
+/**
+ * Take a lock whose holder is presumed dead, answering whether a retry is now worth making.
+ *
+ * **The removal is the steal.** Reading the mtime only reaches a verdict; the sidecar is still
+ * there, so a re-`mkdir` that followed a bare verdict would fail `AlreadyExists` against the very
+ * directory being stolen and the waiter would poll to its deadline against a lock nobody holds.
+ * A `stat` that fails or reports no mtime is UNKNOWN, and UNKNOWN never steals.
+ *
+ * Losing the re-`mkdir` to another waiter is not a failure of this function: the caller reads
+ * `held` and keeps polling, which is the right answer once someone else holds it.
+ */
 const stealIfStale = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<boolean, never> =>
 	Effect.gen(function* () {
 		const probed = yield* Effect.result(fs.stat(lockDir));
 		if (Result.isFailure(probed)) return false;
 		const mtime = probed.success.mtime;
 		if (Option.isNone(mtime)) return false;
-		return Date.now() - mtime.value.getTime() > STALE_LOCK_MS;
+		if (Date.now() - mtime.value.getTime() <= STALE_LOCK_MS) return false;
+		yield* removeLock(fs, lockDir);
+		return true;
 	});
-
-const removeLock = (fs: FileSystem.FileSystem, lockDir: string): Effect.Effect<void, never> =>
-	Effect.ignore(fs.remove(lockDir, {recursive: true}));
 
 /**
  * Wait for and hold the lane's write lock. `acquired` means this writer holds it — release is the

--- a/packages/fabrika-cli/src/lane/append-lock.ts
+++ b/packages/fabrika-cli/src/lane/append-lock.ts
@@ -43,10 +43,18 @@ export const LOCK_DIR_NAME = "events.lock";
 /**
  * A held lock older than this is presumed crashed, not slow, and is stolen.
  *
- * It is a margin over how long a legitimate holder can take, and that is bounded: everything inside
- * the lock is local IO — load, fold, validate, append — because each verb's board read runs before
- * it. Ten seconds is two orders of magnitude over a hold that measures in milliseconds, which is
- * the honest reading of "this process is gone", while staying inside a wait a shell can afford.
+ * It is a margin over how long a legitimate holder can take, and that is bounded only because **no
+ * caller reads the board under the lock**: every appending verb judges against its board read
+ * first, then takes the lock and re-loads, re-folds and appends, so the hold is local IO measured
+ * in milliseconds. Ten seconds is two orders of magnitude over that — the honest reading of "this
+ * process is gone", inside a wait a shell can afford.
+ *
+ * The bound is therefore a property of the callers, and it is the one thing a new caller can break:
+ * a single `yield*` on an HTTP read inside {@link withLedgerLock} puts the hold on the network's
+ * clock instead, where one stalled exchange costs `DEFAULT_HTTP_TIMEOUT_SECONDS` (60s in
+ * `io/gh-api.ts`) and a paginated read costs a multiple of it. A holder that slow is read as
+ * crashed and has its live lock stolen, which is the silent double-append the lock exists to
+ * refuse. `lane settle` shipped exactly that shape and was moved out.
  */
 const STALE_LOCK_MS = 10_000;
 
@@ -164,6 +172,10 @@ export const releaseLedgerLock = (
  * Run one verb body inside the lane's write lock. The inner effect sees the bytes as they are when
  * the lock is already held, so its validation cannot race another writer's append. Release runs on
  * every exit, refusal included.
+ *
+ * **The body is local IO only.** A board read belongs before this call, with the body re-loading and
+ * re-deriving under the lock — the shape every appending verb takes, and what {@link STALE_LOCK_MS}
+ * is a margin over.
  *
  * Two refusals, two seats. `onLocked` is {@link CONCURRENT_WRITE}'s — "retry this same event once
  * the holder clears" — and it belongs only to a lock a live writer holds. `onAbsent` is the lane's

--- a/packages/fabrika-cli/src/lane/append-lock.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/append-lock.unit.test.ts
@@ -3,6 +3,10 @@
  * {@link CONCURRENT_WRITE} — distinguishable from an ordinary machine refusal — with the log left
  * byte-identical, while the uncontended path behaves exactly as it did before the lock existed.
  *
+ * The stale-lock half is here too, and it is the one with three answers rather than two: a lock aged
+ * past the horizon is stolen, a younger one is not, and an explicit budget refuses before either
+ * question is asked. Only the middle of those was ever covered.
+ *
  * Contention here is scripted (`mkdirExisting`), not raced: the point is the *deterministic* half
  * of the guarantee. The probabilistic half — that two live processes actually collide often enough
  * for the guard to matter — lives in [`append-race.cli.test.ts`](append-race.cli.test.ts), which
@@ -150,6 +154,62 @@ describe("lane append lock", {timeout: 10_000}, () => {
 		expect(absent.code).toBe(LANE_ABSENT);
 		expect(held.code).toBe(CONCURRENT_WRITE);
 		expect(held.stderr.join(" ")).toContain("another writer holds");
+	});
+
+	it("a lock aged past the stale horizon is stolen by a waiting writer, not refused", async () => {
+		// The crashed holder: the sidecar is there, its mtime is a minute old, and nothing will ever
+		// release it. Before the fix the waiter reached a `stale` verdict, never removed the
+		// directory, and polled to its deadline against a lock nobody held.
+		const fs = freshLane({
+			mkdirExisting: [LOCK],
+			mtimes: {[LOCK]: new Date(Date.now() - 60_000)},
+		});
+
+		const attempt = await Effect.runPromise(
+			Effect.provide(
+				Effect.gen(function* () {
+					const filesystem = yield* FileSystem.FileSystem;
+					return yield* acquireLedgerLock(filesystem, LOCK, 5_000);
+				}),
+				fs.layer,
+			),
+		);
+
+		expect(attempt).toBe("acquired");
+	});
+
+	it("a lock younger than the stale horizon is still held at deadline, so live contention refuses", async () => {
+		const fs = freshLane({
+			mkdirExisting: [LOCK],
+			mtimes: {[LOCK]: new Date(Date.now() - 200)},
+		});
+
+		const attempt = await Effect.runPromise(
+			Effect.provide(
+				Effect.gen(function* () {
+					const filesystem = yield* FileSystem.FileSystem;
+					return yield* acquireLedgerLock(filesystem, LOCK, 200);
+				}),
+				fs.layer,
+			),
+		);
+
+		// A live writer's lock is not this waiter's to take: stealing it is the silent double-append
+		// the whole lock exists to prevent.
+		expect(attempt).toBe("held");
+	});
+
+	it("a small FABRIKA_LANE_LOCK_BUDGET_MS refuses fast instead of waiting out the derived default", async () => {
+		process.env.FABRIKA_LANE_LOCK_BUDGET_MS = SHORT_LOCK_MS;
+		const fs = freshLane({mkdirExisting: [LOCK], mtimes: {[LOCK]: new Date()}});
+		const started = Date.now();
+
+		const out = await run(fs);
+
+		expect(out.code).toBe(CONCURRENT_WRITE);
+		// The override is the whole point of the knob: the default budget now outlasts the stale
+		// horizon, and a test or interactive shell must not inherit that wait.
+		expect(Date.now() - started).toBeLessThan(2_000);
 	});
 
 	it("the uncontended path appends exactly as before the lock existed", async () => {

--- a/packages/fabrika-cli/src/lane/settle-verb.ts
+++ b/packages/fabrika-cli/src/lane/settle-verb.ts
@@ -203,155 +203,176 @@ export const runSettle = <R = never>(
 	Effect.gen(function* () {
 		const fs = yield* FileSystem.FileSystem;
 		const path = yield* Path.Path;
-		return yield* withLedgerLock(
-			{fs, path, dir: path.join(options.root, options.lane), verb: VERB},
-			Effect.gen(function* () {
-				const {issue} = options;
-				if (issue === null) {
-					return refuse(
-						ISSUE_UNRESOLVED,
-						`${VERB}: "${options.lane}" names no issue, and settling a lane stands on that issue's own closure — a chore lane can never satisfy it. Nothing was appended.`,
-					);
-				}
-				const loaded = yield* loadLane(options);
-				if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
-				const task = resolveTask(loaded.lane, options.task);
-				if (task._tag === "Unresolved") {
-					return refuse(TASK_UNKNOWN, `${VERB}: ${task.reason}`);
-				}
-				const fold = foldLog(loaded.lane, loaded.entries);
-				if (fold._tag !== "Folded") return replayRefusal(VERB, loaded.logPath, fold);
 
-				// The offline gate first: whether there is anything here to settle is a fact about the fold
-				// alone, so a lane already carrying a terminal never costs a board read. Which terminal it
-				// would take is the board's, and both take the same route through the machine.
-				const at = yield* Effect.sync(() => new Date().toISOString());
-				const dry = applyBoardTerminal(
-					loaded.lane,
-					fold.states,
-					task.taskId,
-					CANCELLED_EVENT,
-					{outcome: "not_planned"},
-					at,
+		// Judge here, outside the lock, then re-derive under it — the shape `lane transition` and
+		// `lane reconcile` already take, and load-bearing for the lock itself rather than for cost
+		// alone: `append-lock.ts`'s stale horizon presumes every holder does local IO only, and this
+		// verb's board reads are paginated HTTP bounded by a per-exchange timeout an order of
+		// magnitude past that horizon. A holder awaiting one under the lock would be read as crashed
+		// and have its live lock stolen, which is the silent double-append the lock exists to refuse.
+		const loaded = yield* loadLane(options);
+		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+		const {issue} = options;
+		if (issue === null) {
+			return refuse(
+				ISSUE_UNRESOLVED,
+				`${VERB}: "${options.lane}" names no issue, and settling a lane stands on that issue's own closure — a chore lane can never satisfy it. Nothing was appended.`,
+			);
+		}
+		const task = resolveTask(loaded.lane, options.task);
+		if (task._tag === "Unresolved") {
+			return refuse(TASK_UNKNOWN, `${VERB}: ${task.reason}`);
+		}
+		const fold = foldLog(loaded.lane, loaded.entries);
+		if (fold._tag !== "Folded") return replayRefusal(VERB, loaded.logPath, fold);
+
+		// The offline gate first: whether there is anything here to settle is a fact about the fold
+		// alone, so a lane already carrying a terminal never costs a board read. Which terminal it
+		// would take is the board's, and both take the same route through the machine.
+		const at = yield* Effect.sync(() => new Date().toISOString());
+		const dry = applyBoardTerminal(
+			loaded.lane,
+			fold.states,
+			task.taskId,
+			CANCELLED_EVENT,
+			{outcome: "not_planned"},
+			at,
+		);
+		if (dry._tag === "Refused") {
+			return refuse(EVENT_REFUSED, `${VERB}: refused (log unappended): ${dry.reason}.`);
+		}
+
+		const read = yield* options.closure(issue);
+		if (read._tag === "Unknown") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot establish how #${issue} closed: ${read.reason} — UNKNOWN, and the log is unappended.`,
+			);
+		}
+		if (read.state === "open") {
+			return refuse(
+				ISSUE_LIVE,
+				`${VERB}: #${issue} is open, so this lane is live work — drive it, or close the issue first. Nothing was appended.`,
+			);
+		}
+		// Read only on the arm that needs them: a cancellation stands on the closure alone, and
+		// the named pull request is read only where a caller named one.
+		let facts: ReadonlyArray<PullFact> | null = null;
+		let asserted: AssertedPull | null = null;
+		if (read.reason === "completed") {
+			const nominated = yield* options.pulls(issue);
+			if (nominated._tag === "Unreadable") {
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot read ${nominated.what}: ${nominated.reason} — what landed for #${issue} is UNKNOWN, and the log is unappended.`,
 				);
-				if (dry._tag === "Refused") {
-					return refuse(EVENT_REFUSED, `${VERB}: refused (log unappended): ${dry.reason}.`);
-				}
-
-				const read = yield* options.closure(issue);
-				if (read._tag === "Unknown") {
+			}
+			facts = nominated.pulls;
+			if (options.landedBy !== null) {
+				const named = yield* options.asserted(options.landedBy);
+				if (named._tag === "Unknown") {
 					return refuse(
 						LANE_UNREADABLE,
-						`${VERB}: cannot establish how #${issue} closed: ${read.reason} — UNKNOWN, and the log is unappended.`,
+						`${VERB}: cannot establish whether #${options.landedBy} merged: ${named.reason} — UNKNOWN, and the log is unappended.`,
 					);
 				}
-				if (read.state === "open") {
-					return refuse(
-						ISSUE_LIVE,
-						`${VERB}: #${issue} is open, so this lane is live work — drive it, or close the issue first. Nothing was appended.`,
-					);
-				}
-				// Read only on the arm that needs them: a cancellation stands on the closure alone, and
-				// the named pull request is read only where a caller named one.
-				let facts: ReadonlyArray<PullFact> | null = null;
-				let asserted: AssertedPull | null = null;
-				if (read.reason === "completed") {
-					const nominated = yield* options.pulls(issue);
-					if (nominated._tag === "Unreadable") {
-						return refuse(
-							LANE_UNREADABLE,
-							`${VERB}: cannot read ${nominated.what}: ${nominated.reason} — what landed for #${issue} is UNKNOWN, and the log is unappended.`,
-						);
-					}
-					facts = nominated.pulls;
-					if (options.landedBy !== null) {
-						const named = yield* options.asserted(options.landedBy);
-						if (named._tag === "Unknown") {
-							return refuse(
-								LANE_UNREADABLE,
-								`${VERB}: cannot establish whether #${options.landedBy} merged: ${named.reason} — UNKNOWN, and the log is unappended.`,
-							);
-						}
-						asserted = named;
-					}
-				}
-				const entitled = entitlement(issue, read.state, read.reason, facts, asserted);
-				if (entitled._tag === "Unknown") {
-					return refuse(
-						LANE_UNREADABLE,
-						`${VERB}: ${entitled.reason} — UNKNOWN, and the log is unappended.`,
-					);
-				}
-				if (entitled._tag === "AssertedAbsent") {
-					return refuse(
-						PROOF_ABSENT,
-						`${VERB}: --landed-by names #${entitled.pr}, which is not a pull request on this repository — an asserted landing supplies the link a body lacks and never the merge itself. Nothing was appended.`,
-					);
-				}
-				if (entitled._tag === "AssertedUnmerged") {
-					return refuse(
-						PROOF_IN_FLIGHT,
-						`${VERB}: --landed-by names #${entitled.pr}, which the board reads "${entitled.state}" and not merged — there is no landing to record until it merges. Nothing was appended.`,
-					);
-				}
-				if (entitled._tag === "Live") {
-					return refuse(
-						ISSUE_LIVE,
-						`${VERB}: #${issue} is open, so this lane is live work — drive it, or close the issue first. Nothing was appended.`,
-					);
-				}
+				asserted = named;
+			}
+		}
+		const entitled = entitlement(issue, read.state, read.reason, facts, asserted);
+		if (entitled._tag === "Unknown") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: ${entitled.reason} — UNKNOWN, and the log is unappended.`,
+			);
+		}
+		if (entitled._tag === "AssertedAbsent") {
+			return refuse(
+				PROOF_ABSENT,
+				`${VERB}: --landed-by names #${entitled.pr}, which is not a pull request on this repository — an asserted landing supplies the link a body lacks and never the merge itself. Nothing was appended.`,
+			);
+		}
+		if (entitled._tag === "AssertedUnmerged") {
+			return refuse(
+				PROOF_IN_FLIGHT,
+				`${VERB}: --landed-by names #${entitled.pr}, which the board reads "${entitled.state}" and not merged — there is no landing to record until it merges. Nothing was appended.`,
+			);
+		}
+		if (entitled._tag === "Live") {
+			return refuse(
+				ISSUE_LIVE,
+				`${VERB}: #${issue} is open, so this lane is live work — drive it, or close the issue first. Nothing was appended.`,
+			);
+		}
 
-				const claimed = yield* options.claims(issue);
-				if (claimed._tag === "Unknown") {
-					return refuse(
-						LANE_UNREADABLE,
-						`${VERB}: cannot establish whether #${issue} carries a live lane claim: ${claimed.reason} — UNKNOWN, never "unclaimed", and the log is unappended.`,
-					);
-				}
-				const holder = claimed.holder;
-				if (holder !== null && holder.token !== options.token) {
-					return refuse(
-						CLAIM_NOT_MINE,
-						`${VERB}: #${issue} carries the live lane claim ${holder.token} — a lane another session is driving is not one to end underneath it. Pass --token ${holder.token} if that driver is you, or clear the seat through \`fabrika lane adopt ${options.lane}\` then \`fabrika lane release\`. Nothing was appended.`,
-					);
-				}
+		const claimed = yield* options.claims(issue);
+		if (claimed._tag === "Unknown") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot establish whether #${issue} carries a live lane claim: ${claimed.reason} — UNKNOWN, never "unclaimed", and the log is unappended.`,
+			);
+		}
+		const holder = claimed.holder;
+		if (holder !== null && holder.token !== options.token) {
+			return refuse(
+				CLAIM_NOT_MINE,
+				`${VERB}: #${issue} carries the live lane claim ${holder.token} — a lane another session is driving is not one to end underneath it. Pass --token ${holder.token} if that driver is you, or clear the seat through \`fabrika lane adopt ${options.lane}\` then \`fabrika lane release\`. Nothing was appended.`,
+			);
+		}
 
-				let evidence: SettlementEvidence = {outcome: entitled.outcome};
-				if (entitled._tag === "Landed") {
-					const first = entitled.landed[0];
-					// An asserted landing was read in full a moment ago, so its merge commit is already
-					// in hand; a body-proven one names PRs the nomination read carries no sha for.
-					const sha =
-						entitled.assertedBy !== undefined && asserted !== null && asserted._tag === "Merged"
-							? asserted.sha
-							: first === undefined
-								? null
-								: yield* options.sha(first);
-					evidence = {
-						outcome: entitled.outcome,
-						landed: entitled.landed,
-						...(sha === null ? {} : {sha}),
-						...(entitled.assertedBy === undefined ? {} : {assertedBy: entitled.assertedBy}),
-					};
+		let evidence: SettlementEvidence = {outcome: entitled.outcome};
+		if (entitled._tag === "Landed") {
+			const first = entitled.landed[0];
+			// An asserted landing was read in full a moment ago, so its merge commit is already
+			// in hand; a body-proven one names PRs the nomination read carries no sha for.
+			const sha =
+				entitled.assertedBy !== undefined && asserted !== null && asserted._tag === "Merged"
+					? asserted.sha
+					: first === undefined
+						? null
+						: yield* options.sha(first);
+			evidence = {
+				outcome: entitled.outcome,
+				landed: entitled.landed,
+				...(sha === null ? {} : {sha}),
+				...(entitled.assertedBy === undefined ? {} : {assertedBy: entitled.assertedBy}),
+			};
+		}
+
+		return yield* withLedgerLock(
+			{fs, path, dir: loaded.dir, verb: VERB},
+			Effect.gen(function* () {
+				// Re-load and re-derive under the lock: between the judgement above and this append a
+				// concurrent writer may have moved the lane, and a terminal validated against a fold
+				// that no longer stands is the corruption the lock exists to refuse.
+				const fresh = yield* loadLane(options);
+				if (fresh._tag !== "Loaded") return loadRefusal(VERB, fresh);
+				const freshTask = resolveTask(fresh.lane, options.task);
+				if (freshTask._tag === "Unresolved") {
+					return refuse(TASK_UNKNOWN, `${VERB}: ${freshTask.reason}`);
 				}
+				const freshFold = foldLog(fresh.lane, fresh.entries);
+				if (freshFold._tag !== "Folded") return replayRefusal(VERB, fresh.logPath, freshFold);
+
+				const now = yield* Effect.sync(() => new Date().toISOString());
 				const applied = applyBoardTerminal(
-					loaded.lane,
-					fold.states,
-					task.taskId,
+					fresh.lane,
+					freshFold.states,
+					freshTask.taskId,
 					entitled.event,
 					evidence,
-					at,
+					now,
 				);
 				if (applied._tag === "Refused") {
 					return refuse(EVENT_REFUSED, `${VERB}: refused (log unappended): ${applied.reason}.`);
 				}
 				const wrote = yield* Effect.result(
-					appendText(loaded.logPath, `${JSON.stringify(applied.entry)}\n`),
+					appendText(fresh.logPath, `${JSON.stringify(applied.entry)}\n`),
 				);
 				if (Result.isFailure(wrote)) {
 					return refuse(
 						APPEND_UNKNOWN,
-						`${VERB}: the append to ${loaded.logPath} did not land: ${wrote.failure.reason} — the terminal is NOT recorded.`,
+						`${VERB}: the append to ${fresh.logPath} did not land: ${wrote.failure.reason} — the terminal is NOT recorded.`,
 					);
 				}
 				return answer(
@@ -363,7 +384,7 @@ export const runSettle = <R = never>(
 							previous: applied.previous.stateValue,
 							event: applied.entry.event,
 							current: applied.current.stateValue,
-							taskAffected: task.taskId,
+							taskAffected: freshTask.taskId,
 							outcome: entitled.outcome,
 							...(evidence.landed === undefined ? {} : {landed: evidence.landed}),
 							...(evidence.sha === undefined ? {} : {sha: evidence.sha}),
@@ -373,7 +394,7 @@ export const runSettle = <R = never>(
 						2,
 					),
 					[
-						`${VERB}: appended ${applied.entry.event} to ${loaded.logPath}; #${issue} is closed as ${entitled.outcome}${
+						`${VERB}: appended ${applied.entry.event} to ${fresh.logPath}; #${issue} is closed as ${entitled.outcome}${
 							evidence.landed === undefined
 								? ""
 								: ` over ${evidence.landed.map((pr) => `#${pr}`).join(", ")}`

--- a/packages/fabrika-cli/src/lane/settle-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/settle-verb.unit.test.ts
@@ -11,6 +11,7 @@ import {fakeFs} from "../fakes.test-support.ts";
 import type {ClaimHoldReader} from "./claim-hold.ts";
 import {
 	CLAIM_NOT_MINE,
+	CONCURRENT_WRITE,
 	EVENT_REFUSED,
 	ISSUE_LIVE,
 	ISSUE_UNRESOLVED,
@@ -39,6 +40,7 @@ const LANE = "5983";
 const DIR = `${ROOT}/${LANE}`;
 const WORKFLOW = `${DIR}/workflow.json`;
 const LOG = `${DIR}/events.jsonl`;
+const LOCK = `${DIR}/events.lock`;
 const ISSUE = 5983;
 const SHA = "b0ab5804263e3ca232aa950e906b997e0e6b1963";
 
@@ -583,5 +585,37 @@ describe("lane settle — what never reaches a terminal", () => {
 		const fs = laneFs();
 
 		expect((await settle(fs, {task: "nope"})).code).toBe(TASK_UNKNOWN);
+	});
+
+	it("reads the board before it takes the write lock, so a holder never waits on the network", async () => {
+		// `append-lock.ts`'s stale horizon is a margin over a hold that is local IO only. A board read
+		// under the lock puts the hold on the network's clock instead, and a live lock long enough to
+		// pass the horizon is stolen — the double-append the lock exists to refuse. Proven from
+		// outside the verb: with the lock held by someone else for the whole run, the closure read
+		// still happened, so it cannot have been sequenced behind the acquire.
+		process.env.FABRIKA_LANE_LOCK_BUDGET_MS = "120";
+		const fs = fakeFs({
+			files: {[WORKFLOW]: coderTemplateText(), [LOG]: PARKED},
+			dirs: {[ROOT]: [LANE]},
+			directories: [ROOT],
+			mkdirExisting: [LOCK],
+			mtimes: {[LOCK]: new Date()},
+		});
+		let reads = 0;
+		const counted: ClosureReader<never> = () =>
+			Effect.sync(() => {
+				reads += 1;
+				return {_tag: "Read" as const, state: "closed" as const, reason: "not_planned"};
+			});
+
+		try {
+			const out = await settle(fs, {closure: counted});
+
+			expect(out.code).toBe(CONCURRENT_WRITE);
+			expect(reads).toBe(1);
+			expect(fs.written.has(LOG)).toBe(false);
+		} finally {
+			delete process.env.FABRIKA_LANE_LOCK_BUDGET_MS;
+		}
 	});
 });


### PR DESCRIPTION
Fixes #9093

The lane ledger's write lock had two defects stacked on each other, and together they lost a
shell's terminal on lane 9080.

**The steal never removed anything.** `stealIfStale` read the lock directory's mtime, answered
`true` for a lock past the stale horizon — and returned. The sidecar was still on disk, so the
re-`mkdir` immediately after it failed `AlreadyExists` against the very directory being stolen.
Every waiter polled to its deadline against a lock nobody held. The removal is now the steal.

**The wait budget could not reach the horizon.** `DEFAULT_LOCK_BUDGET_MS` was 5s and
`STALE_LOCK_MS` was 60s, so even with a working steal a crashed holder's lock was un-stealable for
its first 55 seconds and every writer arriving inside that window refused `CONCURRENT_WRITE`.
The horizon is now the one knob: it drops to 10s and the default budget derives from it as
`STALE_LOCK_MS + 20 * POLL_MS`. Tuning one of them alone can no longer re-open the gap, which is
what the top-of-file docblock now says in as many words.

**A 10s horizon only holds if no holder waits on the network, and one did.** The review caught that
`lane settle` awaited its board reads — `getIssue`, a paginated `nominatePulls`, `readClaimants` —
inside `withLedgerLock`, where a single stalled exchange costs the 60s gh timeout. A holder that
slow reads as crashed, so the now-live steal would take a lock a live writer holds: a silent
double-append, worse than the refusal this issue set out to fix. `lane settle` now judges outside
the lock and re-loads, re-folds and appends under it, the shape `lane transition`, `lane report`,
`lane reconcile` and `lane amend` already take. That makes it the last caller whose hold was
anything but local IO, so the horizon's premise is now true of every caller — and the docblock
states the premise as a property of the callers, names the gh timeout as what breaks it, and says
where a new board read belongs.

`FABRIKA_LANE_LOCK_BUDGET_MS` still overrides the budget, and a test holds that a small override
refuses fast rather than inheriting the longer default.

A reviewer should look first at `stealIfStale` in
`packages/fabrika-cli/src/lane/append-lock.ts` — the missing `removeLock` is the load-bearing line
— then at `runSettle`'s new split, and then at the `mkdirExisting` change in
`fakes.test-support.ts`, which makes a scripted held lock removable so a steal that lands is
distinguishable from one that changes nothing. Without that, the fake would have greened the broken
code. The settle split has its own regression test: with the lock held for the whole run, the
closure read still happens, which it could not if it were sequenced behind the acquire.

## Deviations

- **Out-of-scope change** — **Said:** the issue frames the buildable half as the constants, naming
  three knobs and leaving the choice to the builder. **Did:** also fixed `stealIfStale` to remove
  the lock directory. **Why:** the acceptance criterion asks for a waiting writer to actually steal
  an aged lock, and no arrangement of the constants produces that while the steal is a verdict with
  no removal — the re-`mkdir` fails against the directory it is stealing. **Disposition:** stated
  here; it is the same defect the issue names, one layer down.
- **Out-of-scope change** — **Said:** the pointers name `append-lock.ts` and its two test files.
  **Did:** also changed `packages/fabrika-cli/src/fakes.test-support.ts` so `mkdirExisting` models a
  removable lock that `stat`s as a directory. **Why:** the first acceptance criterion needs a
  planted aged lock a steal can succeed against, and the fake previously failed `mkdir` forever
  regardless of removal. **Disposition:** stated here; `mkdirExisting` has exactly one consumer, the
  lock's own unit test.
- **Out-of-scope change** — **Said:** the issue names `append-lock.ts` and lists the six callers as
  inheriting the fix, not as files to change. **Did:** also restructured `runSettle` in
  `packages/fabrika-cli/src/lane/settle-verb.ts` so its board reads run before the lock, plus one
  regression test. **Why:** the shortened horizon is only safe while every holder does local IO, and
  `lane settle` was the one caller that did not — leaving it would have made a live lock stealable.
  **Disposition:** stated here; behaviour is unchanged on every arm, the gate order and the
  read-only-on-the-arm-that-needs-it cost rule are preserved, and the whole 1226-test lane suite
  passes.
