### PR TITLE
fix: Lane brief reports a present module absent from a package cwd

### DIFF
--- a/packages/fabrika-cli/src/governance/base-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/base-verb.unit.test.ts
@@ -156,7 +156,7 @@ describe("runBase", () => {
 		const fake = fakeSeams(happy);
 		await Effect.runPromise(Effect.provide(runBase(options), fake.layer));
 		expect(fake.calls.some((call) => call.startsWith("git checkout"))).toBe(false);
-		expect(fake.calls).toContain(`git ls-tree -r --name-only -z ${MERGE_BASE}`);
+		expect(fake.calls).toContain(`git ls-tree -r --full-tree --name-only -z ${MERGE_BASE}`);
 		expect(fake.calls).toContain(`git rev-parse --verify --quiet ${HEAD}^{commit}`);
 	});
 });
@@ -260,6 +260,6 @@ describe("runBase over a range", () => {
 		await Effect.runPromise(Effect.provide(runBase({...options, ...ranged}), fake.layer));
 		expect(fake.requests).toEqual([]);
 		expect(fake.calls.some((call) => call.startsWith("git checkout"))).toBe(false);
-		expect(fake.calls).toContain(`git ls-tree -r --name-only -z ${RANGE_MERGE_BASE}`);
+		expect(fake.calls).toContain(`git ls-tree -r --full-tree --name-only -z ${RANGE_MERGE_BASE}`);
 	});
 });

--- a/packages/fabrika-cli/src/governance/digest-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/digest-verb.unit.test.ts
@@ -17,7 +17,7 @@ const RESOLVE = [
 ] as const;
 const SHALLOW = [/^git rev-parse --is-shallow-repository$/, okOut("false\n")] as const;
 const TREE = [
-	new RegExp(`^git ls-tree -r --name-only -z ${BASE_SHA}$`),
+	new RegExp(`^git ls-tree -r --full-tree --name-only -z ${BASE_SHA}$`),
 	okOut(`${PATH}\0.decisions/0238-fabrika-reimplements-v1.md\0src/cart.ts\0`),
 ] as const;
 const LOG = [

--- a/packages/fabrika-cli/src/governance/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/governance/fixtures.test-support.ts
@@ -44,7 +44,7 @@ export const statuses = (...rows: ReadonlyArray<StatusRow>): ExecResult =>
 
 /** The recursive tree read this group resolves a skill root and root presence from. */
 export const TREE_AT = (sha: string = HEAD): RegExp =>
-	new RegExp(`^git ls-tree -r --name-only -z ${sha}$`);
+	new RegExp(`^git ls-tree -r --full-tree --name-only -z ${sha}$`);
 
 export const treeOf = (...paths: ReadonlyArray<string>): ExecResult =>
 	okOut(paths.map((path) => `${path}\0`).join(""));

--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -237,10 +237,15 @@ export const fetchAndResolve = (base: string): Shell<Attempt<string>> =>
  *
  * Newline-separated rather than `-z`: a record base name is `NNNN-slug.md` by construction, so
  * there is no name a newline could split, and a plain line grammar keeps the fixtures readable.
+ *
+ * `--full-tree` because `ls-tree` otherwise limits its listing to the process's directory, and this
+ * read's empty answer is a *fact* to its callers — an existing directory holding nothing. Run from
+ * a subdirectory the unanchored form lists nothing at all, which the allocator would read as an
+ * empty corpus and hand back `0001`.
  */
 export const listDir = (sha: string, dir: string): Shell<Attempt<ReadonlyArray<string>>> =>
 	Effect.gen(function* () {
-		const r = yield* execCapture("git", ["ls-tree", "--name-only", `${sha}:${dir}`]);
+		const r = yield* execCapture("git", ["ls-tree", "--full-tree", "--name-only", `${sha}:${dir}`]);
 		if (!r.ok) return fail(r.reason);
 		return ok(
 			r.stdout
@@ -340,10 +345,16 @@ export const diffRangeStatuses = (
 		return r.ok ? ok(parseNameStatus(r.stdout)) : fail(r.reason);
 	});
 
-/** Every tracked path at `sha`, recursively — how a fenced skill root is resolved without a checkout. */
+/**
+ * Every tracked path at `sha`, recursively — how a fenced skill root is resolved without a checkout.
+ *
+ * `--full-tree` because "every" is repository-wide: unanchored, `ls-tree` lists only the process's
+ * directory and names those paths relative to it, so a scan run from a package would both miss the
+ * rest of the tree and fail to match any repo-root path its caller compares against.
+ */
 export const listTreePaths = (sha: string): Shell<Attempt<ReadonlyArray<string>>> =>
 	Effect.gen(function* () {
-		const r = yield* execCapture("git", ["ls-tree", "-r", "--name-only", "-z", sha]);
+		const r = yield* execCapture("git", ["ls-tree", "-r", "--full-tree", "--name-only", "-z", sha]);
 		return r.ok ? ok(r.stdout.split("\0").filter((p) => p !== "")) : fail(r.reason);
 	});
 

--- a/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
@@ -813,7 +813,7 @@ describe("lane brief on an epic lane", () => {
 		entrypoint: "packages/fabrika-cli/src/bin.ts",
 	} as EntrypointRead;
 	const EPIC_TREE = "0d4f2a6c8e1b3d5f7a9c2e4b6d8f0a2c4e6b8d0f";
-	const LS_TREE = /^git ls-tree --name-only /;
+	const LS_TREE = /^git ls-tree --full-tree --name-only /;
 	const REPORT_MODULE = "packages/fabrika-cli/src/lane/report-verb.ts";
 
 	const readingBranch = (holds: boolean): ReadonlyArray<Scripted> => [

--- a/packages/fabrika-cli/src/lane/briefed-verbs.ts
+++ b/packages/fabrika-cli/src/lane/briefed-verbs.ts
@@ -80,9 +80,21 @@ export const carriedVerbs = (
 		const missing: BriefedLaneVerb[] = [];
 		for (const verb of BRIEFED_LANE_VERBS) {
 			const file = modulePath(path, entrypoint, verb);
-			const listed = yield* execCapture("git", ["ls-tree", "--name-only", sha, "--", file]);
-			// `ls-tree` exits 0 whether or not the path is in the tree, so an empty answer is a PROVEN
-			// absence and a non-zero exit is the read itself failing — the two must not collapse.
+			const listed = yield* execCapture("git", [
+				"ls-tree",
+				"--full-tree",
+				"--name-only",
+				sha,
+				"--",
+				file,
+			]);
+			// `--full-tree` is what leaves only two cases here: git resolves a bare pathspec against the
+			// process's directory, so run from `packages/fabrika-cli` this read asked the tree about
+			// `packages/fabrika-cli/packages/fabrika-cli/…` and got back the same empty answer a real
+			// absence gives. Anchored to the repository root, that third case cannot arise, and
+			// `ls-tree` still exits 0 whether or not the path is in the tree — so an empty answer is a
+			// PROVEN absence and a non-zero exit is the read itself failing, and the two must not
+			// collapse.
 			if (!listed.ok) {
 				return {
 					_tag: "Unreadable",

--- a/packages/fabrika-cli/src/lane/briefed-verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/briefed-verbs.unit.test.ts
@@ -18,10 +18,41 @@ const REPORT = "packages/fabrika-cli/src/lane/report-verb.ts";
 const SHA = "6f1a2c4d8e0b3a5f7c9d1e2b4a6c8e0d2f4a6b8c";
 
 const RESOLVE = /^git rev-parse --verify --quiet epic\/5817\^\{commit\}$/;
-const LS_TREE = /^git ls-tree --name-only /;
+const LS_TREE = /^git ls-tree --full-tree --name-only /;
 
-const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>, entrypoint = SOURCE) => {
-	const shell = fakeShell(script);
+/** One scripted command line, matched whole so a pathspec that differs cannot answer for it. */
+const argv = (line: string): RegExp =>
+	new RegExp(`^${line.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`);
+
+/**
+ * The `ls-tree` reads that answer non-empty in a repo whose tree holds `tree`, run with cwd `cwd`.
+ *
+ * Git resolves a `--full-tree` pathspec against the repository root and a bare one against the
+ * process's directory, so one file is reached by two different argv lines depending on where the
+ * process stands. Everything else falls through to the caller's empty-stdout fallback — the exit-0
+ * answer git gives an unmatched pathspec, which is what this module reads as absence.
+ */
+const treeReadsFrom = (
+	cwd: string,
+	tree: ReadonlyArray<string>,
+): ReadonlyArray<readonly [RegExp, ExecResult]> =>
+	tree.flatMap((file) => {
+		const fromCwd =
+			cwd === "" ? file : file.startsWith(`${cwd}/`) ? file.slice(cwd.length + 1) : null;
+		return [
+			[argv(`git ls-tree --full-tree --name-only ${SHA} -- ${file}`), okOut(`${file}\n`)] as const,
+			...(fromCwd === null
+				? []
+				: [[argv(`git ls-tree --name-only ${SHA} -- ${fromCwd}`), okOut(`${file}\n`)] as const]),
+		];
+	});
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	entrypoint = SOURCE,
+	fallback?: ExecResult,
+) => {
+	const shell = fakeShell(script, fallback);
 	return Effect.runPromise(
 		Effect.provide(
 			Effect.gen(function* () {
@@ -42,7 +73,7 @@ describe("carriedVerbs", () => {
 
 		expect(carriage._tag).toBe("Carried");
 		// The path is read out of the branch's tree by sha, never out of the working tree on disk.
-		expect(calls).toContain(`git ls-tree --name-only ${SHA} -- ${REPORT}`);
+		expect(calls).toContain(`git ls-tree --full-tree --name-only ${SHA} -- ${REPORT}`);
 	});
 
 	it("names every verb the tree does not hold, and reads it as absence rather than as a failure", async () => {
@@ -76,6 +107,30 @@ describe("carriedVerbs", () => {
 		expect(carriage._tag).toBe("Carried");
 		expect(calls).toEqual([]);
 	});
+
+	for (const cwd of ["", "packages/fabrika-cli"]) {
+		const where = cwd === "" ? "the repository root" : cwd;
+
+		it(`answers carried for a present module from ${where}`, async () => {
+			const {carriage} = await run(
+				[[RESOLVE, okOut(`${SHA}\n`)], ...treeReadsFrom(cwd, [REPORT])],
+				SOURCE,
+				okOut(""),
+			);
+
+			expect(carriage._tag).toBe("Carried");
+		});
+
+		it(`answers missing for a genuinely absent module from ${where}`, async () => {
+			const {carriage} = await run(
+				[[RESOLVE, okOut(`${SHA}\n`)], ...treeReadsFrom(cwd, [])],
+				SOURCE,
+				okOut(""),
+			);
+
+			expect(carriage).toEqual({_tag: "Missing", verbs: ["report"]});
+		});
+	}
 
 	it("maps every briefed verb to a module this tree actually has", () => {
 		for (const verb of BRIEFED_LANE_VERBS) {

--- a/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
@@ -17,8 +17,8 @@ const shell = (overrides: Script = [], slug = "worker-queue-retry") =>
 		[/^git remote$/, okOut("origin\n")],
 		[/^git fetch/, okOut("")],
 		[/^git rev-parse/, okOut(`${SHA}\n`)],
-		[/^git ls-tree --name-only \w+ -- \S+\.md$/, okOut(`${DIR}/${slug}.md\n`)],
-		[/^git ls-tree --name-only \w+ -- \S+\.yaml$/, okOut(`${MANIFEST}\n`)],
+		[/^git ls-tree --full-tree --name-only \w+ -- \S+\.md$/, okOut(`${DIR}/${slug}.md\n`)],
+		[/^git ls-tree --full-tree --name-only \w+ -- \S+\.yaml$/, okOut(`${MANIFEST}\n`)],
 		[/^git show \w+:\S+\.yaml$/, okOut(FIXTURE_MANIFEST)],
 		[/^git show \w+:\S+plain-doc\.md$/, okOut(PLAIN_DOC)],
 		[/^git show \w+:/, okOut(ANCHORED_DOC)],
@@ -167,7 +167,7 @@ describe("runAnchor", () => {
 	});
 	// The degrade path: a repo that pins nothing centrally is a fact about that repo, not a failure.
 	it("degrades to `unpinned` at exit 0 when the manifest is absent, and says so on stderr", async () => {
-		const out = await run([[/^git ls-tree --name-only \w+ -- \S+\.yaml$/, okOut("")]]);
+		const out = await run([[/^git ls-tree --full-tree --name-only \w+ -- \S+\.yaml$/, okOut("")]]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe("anchor\tunpinned\t2\t0\t2\t0");
 		expect(out.stderr.join("\n")).toContain("is absent at");
@@ -183,7 +183,7 @@ describe("runAnchor", () => {
 	// `unborn` mirrors `pattern drift` deliberately: one tree state must not produce two verdicts.
 	it("answers `unborn` for a doc in the working tree and absent at the base", async () => {
 		const out = await run(
-			[[/^git ls-tree --name-only \w+ -- \S+\.md$/, okOut("")]],
+			[[/^git ls-tree --full-tree --name-only \w+ -- \S+\.md$/, okOut("")]],
 			{},
 			{
 				[`${DIR}/worker-queue-retry.md`]: "# New\n",
@@ -194,7 +194,7 @@ describe("runAnchor", () => {
 	});
 
 	it("refuses a slug with no doc anywhere on the same code pattern drift uses", async () => {
-		const out = await run([[/^git ls-tree --name-only \w+ -- \S+\.md$/, okOut("")]], {
+		const out = await run([[/^git ls-tree --full-tree --name-only \w+ -- \S+\.md$/, okOut("")]], {
 			slug: "no-such-doc",
 		});
 		expect(out.code).toBe(DOC_ABSENT);

--- a/packages/fabrika-cli/src/pattern/corpus-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/corpus-verb.unit.test.ts
@@ -26,8 +26,11 @@ const base = (overrides: Script = [], dir = ".patterns") =>
 		[/^git remote$/, okOut("origin\n")],
 		[/^git fetch/, okOut("")],
 		[/^git rev-parse/, okOut(`${SHA}\n`)],
-		[/^git ls-tree --name-only \w+ --/, okOut(`${dir}\n`)],
-		[/^git ls-tree --name-only \w+:/, okOut(tree("index.md", "registered.md", "orphan.md"))],
+		[/^git ls-tree --full-tree --name-only \w+ --/, okOut(`${dir}\n`)],
+		[
+			/^git ls-tree --full-tree --name-only \w+:/,
+			okOut(tree("index.md", "registered.md", "orphan.md")),
+		],
 		[/^git show \w+:.*index\.md$/, okOut(INDEX)],
 		[/^git log -1/, okOut(`${DOC_SHA}\t2026-08-09\n`)],
 	]);
@@ -59,9 +62,12 @@ describe("runCorpus", () => {
 
 	// The contract's first worked example, byte for byte.
 	it("answers `none` at exit 0 for a library that exists and is empty", async () => {
-		const out = await run([[/^git ls-tree --name-only \w+:/, okOut(tree("index.md"))]], {
-			dir: `${FIXTURES}/empty-library`,
-		});
+		const out = await run(
+			[[/^git ls-tree --full-tree --name-only \w+:/, okOut(tree("index.md"))]],
+			{
+				dir: `${FIXTURES}/empty-library`,
+			},
+		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("corpus\tnone\t0\t0\t0\t0\n");
 	});
@@ -69,7 +75,7 @@ describe("runCorpus", () => {
 	// The contract's second worked example. `no-library` is deliberately not a committed directory —
 	// it is the absent path, and a fixture that existed could not demonstrate this outcome.
 	it("answers `absent` at exit 0 when --dir is not in the tree", async () => {
-		const out = await run([[/^git ls-tree --name-only \w+ --/, okOut("")]], {
+		const out = await run([[/^git ls-tree --full-tree --name-only \w+ --/, okOut("")]], {
 			dir: `${FIXTURES}/no-library`,
 		});
 		expect(out.code).toBe(0);
@@ -78,10 +84,13 @@ describe("runCorpus", () => {
 
 	// The contract's third worked example.
 	it("carries the same empty answer through --json", async () => {
-		const out = await run([[/^git ls-tree --name-only \w+:/, okOut(tree("index.md"))]], {
-			dir: `${FIXTURES}/empty-library`,
-			json: true,
-		});
+		const out = await run(
+			[[/^git ls-tree --full-tree --name-only \w+:/, okOut(tree("index.md"))]],
+			{
+				dir: `${FIXTURES}/empty-library`,
+				json: true,
+			},
+		);
 		expect(out.stdout).toBe(
 			`{"outcome":"none","docs":0,"unregistered":0,"unknown":0,"dangling":0,"entries":[],"danglingRows":[],"baseRef":"origin/main","baseSha":"${SHA}"}\n`,
 		);
@@ -99,7 +108,7 @@ describe("runCorpus", () => {
 
 	it("refuses a tree read that FAILED, and never reads that as `absent`", async () => {
 		const out = await run([
-			[/^git ls-tree --name-only \w+ --/, errOut("fatal: not a tree object")],
+			[/^git ls-tree --full-tree --name-only \w+ --/, errOut("fatal: not a tree object")],
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
@@ -125,7 +134,7 @@ describe("runCorpus", () => {
 
 	it("reports the same when the index is absent altogether", async () => {
 		const out = await run([
-			[/^git ls-tree --name-only \w+:/, okOut(tree("registered.md", "orphan.md"))],
+			[/^git ls-tree --full-tree --name-only \w+:/, okOut(tree("registered.md", "orphan.md"))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe("corpus\tlibrary\t2\t0\t2\t0");

--- a/packages/fabrika-cli/src/pattern/drift-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/drift-verb.unit.test.ts
@@ -32,12 +32,12 @@ const shell = (overrides: Script = []) =>
 		[/^git fetch/, okOut("")],
 		[/^git rev-parse/, okOut(`${SHA}\n`)],
 		[
-			/^git ls-tree --name-only \w+ -- \.patterns\/worker-queue-retry\.md$/,
+			/^git ls-tree --full-tree --name-only \w+ -- \.patterns\/worker-queue-retry\.md$/,
 			okOut(".patterns/worker-queue-retry.md\n"),
 		],
-		[/^git ls-tree --name-only \w+:$/, okOut(TOP_LEVEL)],
+		[/^git ls-tree --full-tree --name-only \w+:$/, okOut(TOP_LEVEL)],
 		[
-			/^git ls-tree --name-only \w+ --/,
+			/^git ls-tree --full-tree --name-only \w+ --/,
 			okOut("packages/fabrika-cli/src/bin.ts\nservices/api/router.ts\n"),
 		],
 		[/^git show \w+:/, okOut(DOC)],
@@ -78,8 +78,11 @@ describe("runDrift", () => {
 	// one by resolution alone.
 	it("names every unresolved candidate on stderr rather than reporting it as drift", async () => {
 		const out = await run([
-			[/^git ls-tree --name-only \w+ -- packages/, okOut("")],
-			[/^git ls-tree --name-only \w+ -- \.patterns/, okOut(".patterns/worker-queue-retry.md\n")],
+			[/^git ls-tree --full-tree --name-only \w+ -- packages/, okOut("")],
+			[
+				/^git ls-tree --full-tree --name-only \w+ -- \.patterns/,
+				okOut(".patterns/worker-queue-retry.md\n"),
+			],
 		]);
 		expect(out.stdout.split("\t")[1]).toBe("unanchored");
 		expect(out.stderr.join("\n")).toContain("never treated as findings");
@@ -97,7 +100,7 @@ describe("runDrift", () => {
 			[
 				[/^git show \w+:/, okOut(UNANCHORED_DOC)],
 				[
-					/^git ls-tree --name-only \w+ -- \S/,
+					/^git ls-tree --full-tree --name-only \w+ -- \S/,
 					okOut(`${FIXTURES}/unanchored-doc/worker-queue-retry.md\n`),
 				],
 			],
@@ -112,7 +115,7 @@ describe("runDrift", () => {
 			[
 				[/^git show \w+:/, okOut(UNANCHORED_DOC)],
 				[
-					/^git ls-tree --name-only \w+ -- \S/,
+					/^git ls-tree --full-tree --name-only \w+ -- \S/,
 					okOut(`${FIXTURES}/unanchored-doc/worker-queue-retry.md\n`),
 				],
 			],
@@ -125,7 +128,9 @@ describe("runDrift", () => {
 
 	// The contract's third worked example.
 	it("refuses a slug with no doc in the working tree and none at the base", async () => {
-		const out = await run([[/^git ls-tree --name-only \w+ --/, okOut("")]], {slug: "no-such-doc"});
+		const out = await run([[/^git ls-tree --full-tree --name-only \w+ --/, okOut("")]], {
+			slug: "no-such-doc",
+		});
 		expect(out.code).toBe(DOC_ABSENT);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
@@ -137,7 +142,7 @@ describe("runDrift", () => {
 	// same token on the same tree state, because the skill runs the two back to back.
 	it("answers `unborn` for a doc present in the working tree and absent at the base", async () => {
 		const out = await run(
-			[[/^git ls-tree --name-only \w+ --/, okOut("")]],
+			[[/^git ls-tree --full-tree --name-only \w+ --/, okOut("")]],
 			{},
 			{
 				".patterns/worker-queue-retry.md": "# New\n",

--- a/packages/fabrika-cli/src/pattern/git.ts
+++ b/packages/fabrika-cli/src/pattern/git.ts
@@ -7,6 +7,11 @@
  * is, so "not in the tree" is a *fact* and a non-zero exit is a *failed read*. That split is what
  * lets `pattern corpus` answer `absent` at exit `0` while still refusing `11` on a read it could not
  * perform — the two would be one answer if absence were inferred from a failure.
+ *
+ * Every probe below is `--full-tree`, which is what keeps that split honest: git resolves a bare
+ * pathspec against the process's directory and limits the listing to it, so from a subdirectory a
+ * present path answers empty and reads as the *fact* of absence. It implies `--full-name`,
+ * so the printed names stay root-relative and comparable to the paths asked about.
  */
 import {Effect} from "effect";
 import {execCapture} from "../io/exec.ts";
@@ -36,7 +41,14 @@ export const presentPathsAt = (
 ): Shell<Attempt<ReadonlySet<string>>> =>
 	Effect.gen(function* () {
 		if (paths.length === 0) return ok<ReadonlySet<string>>(new Set());
-		const r = yield* execCapture("git", ["ls-tree", "--name-only", sha, "--", ...paths]);
+		const r = yield* execCapture("git", [
+			"ls-tree",
+			"--full-tree",
+			"--name-only",
+			sha,
+			"--",
+			...paths,
+		]);
 		if (!r.ok) return fail(r.reason);
 		return ok<ReadonlySet<string>>(
 			new Set(
@@ -58,7 +70,7 @@ export const pathPresentAt = (sha: string, path: string): Shell<Attempt<boolean>
 /** The top-level entries of the tree at `sha` — the segment set a cited path must open with. */
 export const topLevelEntriesAt = (sha: string): Shell<Attempt<ReadonlySet<string>>> =>
 	Effect.gen(function* () {
-		const r = yield* execCapture("git", ["ls-tree", "--name-only", `${sha}:`]);
+		const r = yield* execCapture("git", ["ls-tree", "--full-tree", "--name-only", `${sha}:`]);
 		if (!r.ok) return fail(r.reason);
 		return ok<ReadonlySet<string>>(
 			new Set(


### PR DESCRIPTION
`lane brief`'s carriage preflight asked `git ls-tree` about a repo-relative path without anchoring
it, and git resolves a bare pathspec against the process's directory. Run from
`packages/fabrika-cli`, the read asked the branch's tree about
`packages/fabrika-cli/packages/fabrika-cli/src/lane/report-verb.ts`, got the empty exit-0 answer a
real absence gives, and refused the dispatch at exit 59 — with a remedy (`lane refresh`) that
changes nothing.

`--full-tree` fixes it with no cwd plumbing: git's own docs say it implies `--full-name` and stops
limiting the listing to the current directory, so both the pathspec and the printed names are
repo-root-relative. Verified against real git in this checkout from both cwds before writing the
change.

The criteria's sweep of the other `ls-tree` / `cat-file` reads under `packages/fabrika-cli/src`
turned up three more with the same cwd dependence, all fixed the same way:

- `io/git.ts` `listDir` — `ls-tree --name-only <sha>:<dir>`. `ls-tree` limits its listing to the
  process's directory even for a tree operand, so from a package this returned nothing. Its callers
  read an empty list as a *fact* ("the directory exists and holds nothing"), which would have handed
  the ADR allocator `0001` against a full corpus.
- `io/git.ts` `listTreePaths` — the whole-tree read behind the governance digest/scope/base verbs and
  `guard changed-files`. Unanchored it listed one subdirectory, under cwd-relative names.
- `pattern/git.ts` `presentPathsAt` and `topLevelEntriesAt` — the presence probes the whole `pattern`
  group's absent-vs-unreadable split rests on.

Checked and already safe, so left alone: `build/git.ts` `treePaths` and `pattern/source.ts` both pass
`-C <root>` (documented at the `treePaths` call site as exactly this defect), and `io/git.ts`
`readFileAt` uses `git show <rev>:<path>`, whose object syntax is root-relative unless the path
starts with `./` — confirmed from a package directory.

New unit tests script the spawner as git behaves under each cwd — a `--full-tree` argv hits on the
root-relative path, a bare one only on the path relative to that cwd, everything else falls through
to the empty answer — and assert `Carried` for a present module and `Missing` for an absent one from
both the repo root and `packages/fabrika-cli`. Confirmed the package-cwd case reds without the fix.

A reviewer should look first at the sweep verdicts above: whether `listDir`'s widening is right, and
whether anything else reads an unanchored tree.

Fixes #9110

## Deviations

- **Out-of-scope change** — **Said:** the issue names `carriedVerbs` in `lane/briefed-verbs.ts` as
  the defect. **Did:** also root-anchored `listDir`, `listTreePaths`, `presentPathsAt` and
  `topLevelEntriesAt`. **Why:** the fourth acceptance criterion requires every other `ls-tree` /
  `cat-file` pathspec read in `packages/fabrika-cli/src` to be root-anchored or noted safe, and these
  four are not safe — `listDir`'s empty answer in particular is read as a fact by the ADR id
  allocator. **Disposition:** stated here and in the summary above, with the reads left alone named
  and the reason each is already safe given.
- **Pre-existing test or fixture changed** — **Said:** nothing about existing tests.
  **Did:** added `--full-tree` to the `ls-tree` argv matchers in `lane/brief-verb.unit.test.ts`,
  `governance/fixtures.test-support.ts`, `governance/digest-verb.unit.test.ts`,
  `governance/base-verb.unit.test.ts` and three `pattern/*.unit.test.ts` files. **Why:** those
  matchers pin the exact command line, so the flag is a mechanical update; no assertion's claim
  changed. **Disposition:** stated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
