### PR TITLE
fix: lane archive refuses a quarantined lane directory as #NaN, so its seat cannot be freed

### DIFF
--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -39,7 +39,15 @@ import {expectationReader} from "./expectation.ts";
 import {deriveRepoRoot, onGround, repoGroundRefusal, resolveRootOrRefuse} from "./ground.ts";
 import {runHistory} from "./history-verb.ts";
 import {runIntegrate} from "./integrate-verb.ts";
-import {archivedRoot, defaultRoot, type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
+import {
+	archivedRoot,
+	defaultRoot,
+	keyIssue,
+	type LaneKey,
+	laneRef,
+	parseKey,
+	templateFile,
+} from "./key.ts";
 import {runMigrate} from "./migrate-verb.ts";
 import {runOpen} from "./open-verb.ts";
 import {runPrint} from "./print-verb.ts";
@@ -66,7 +74,7 @@ import {DEFAULT_VIEW_PORT, listeningAt, runView} from "./view-verb.ts";
 
 const laneArgument = Argument.string("lane").pipe(
 	Argument.withDescription(
-		"the lane key — the issue number the lane drives, or `chore:<name>` for a chore lane",
+		"the lane key — the issue number the lane drives, or `chore:<name>` for a chore lane. A directory name carrying a dot-separated suffix after the number (`8012.frozen-deadlock-<stamp>`) still names issue 8012, so a quarantined lane is addressable by every verb here",
 	),
 );
 
@@ -483,7 +491,7 @@ const open = leafCommand(
 				runOpen({
 					...ref,
 					templatePath: templatePath(key._tag),
-					issue: key._tag === "Issue" ? Number(key.lane) : null,
+					issue: keyIssue(key),
 					expectation: expectationReader(Option.getOrNull(repo), process.env),
 					priorLane: priorLaneReader(Option.getOrNull(repo), process.env),
 					cap,
@@ -1132,7 +1140,7 @@ const archive = leafCommand(
 					// A relocated root holds whatever was opened into it, so both templates are
 					// candidates and the lane's own machine id picks — never the root's position.
 					templatePaths: [templatePath("Issue"), templatePath("Chore")],
-					issue: parsed.key._tag === "Issue" ? Number(parsed.key.lane) : null,
+					issue: keyIssue(parsed.key),
 					closed: closedReader(Option.getOrNull(repo), process.env),
 				}),
 			),
@@ -1179,7 +1187,7 @@ const settle = leafCommand(
 			yield* onKey("settle", lane, root, (key, ref) =>
 				runSettle({
 					...ref,
-					issue: key._tag === "Issue" ? Number(key.lane) : null,
+					issue: keyIssue(key),
 					task: Option.getOrNull(task),
 					token: Option.getOrNull(token),
 					landedBy: Option.getOrNull(landedBy),

--- a/packages/fabrika-cli/src/lane/concurrency.ts
+++ b/packages/fabrika-cli/src/lane/concurrency.ts
@@ -28,6 +28,7 @@ import {refuse, type VerbOutcome} from "../verb.ts";
 import type {ClaimHoldReader} from "./claim-hold.ts";
 import {CONCURRENCY_CAPPED, LANE_UNREADABLE} from "./codes.ts";
 import {deriveStatus, foldLog, standingCauses} from "./fold.ts";
+import {rawKeyIssue} from "./key.ts";
 import {loadLane} from "./store.ts";
 
 /** One lane holding a seat, and why it is not free. */
@@ -51,7 +52,9 @@ export type Seats =
 	| {readonly _tag: "Unreadable"; readonly reason: string};
 
 /** Numeric lane ids in numeric order, so a refusal reads the same twice over one root. */
-const byLane = (a: string, b: string): number => Number(a) - Number(b) || a.localeCompare(b);
+const byLane = (a: string, b: string): number =>
+	(rawKeyIssue(a) ?? Number.POSITIVE_INFINITY) - (rawKeyIssue(b) ?? Number.POSITIVE_INFINITY) ||
+	a.localeCompare(b);
 
 export const seatsIn = <R = never>(
 	root: string,

--- a/packages/fabrika-cli/src/lane/key.ts
+++ b/packages/fabrika-cli/src/lane/key.ts
@@ -84,3 +84,31 @@ export const laneRef = (key: LaneKey, root: string | null): LaneRef => ({
  */
 export const templateFile = (kind: LaneKey["_tag"]): string =>
 	kind === "Chore" ? "chore.workflow.json" : "coder.workflow.json";
+
+/**
+ * A lane key's leading numeric segment, dot-separated from whatever follows it.
+ *
+ * The separator is required rather than optional: `8012abc` names no issue, and resolving it to
+ * 8012 would send a board read at an issue this directory does not drive.
+ */
+const ISSUE_SEGMENT = /^(\d+)(?:\.[^/]+)?$/;
+
+/**
+ * The issue a key drives, or `null` when it names none — a chore lane, or a directory name carrying
+ * no leading issue number.
+ *
+ * The one place this parse lives. Reading a whole directory name as a number yields `NaN` for the
+ * quarantine convention `<issue>.frozen-deadlock-<timestamp>`, which every board read then asks
+ * about as `#NaN` and refuses UNKNOWN — stranding the seat with no verb able to free it.
+ */
+export const keyIssue = (key: LaneKey): number | null => {
+	if (key._tag === "Chore") return null;
+	const matched = ISSUE_SEGMENT.exec(key.lane);
+	return matched?.[1] === undefined ? null : Number(matched[1]);
+};
+
+/** The same resolution from a raw key, for a sweep reading directory names off a root. */
+export const rawKeyIssue = (raw: string): number | null => {
+	const parsed = parseKey(raw);
+	return parsed._tag === "Key" ? keyIssue(parsed.key) : null;
+};

--- a/packages/fabrika-cli/src/lane/key.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/key.unit.test.ts
@@ -1,6 +1,6 @@
 /** The lane key — which kind an argument names, where it lands, and the names it refuses. */
 import {describe, expect, it} from "vitest";
-import {CHORE_NAME_LIMIT, laneRef, parseKey, templateFile} from "./key.ts";
+import {CHORE_NAME_LIMIT, keyIssue, laneRef, parseKey, rawKeyIssue, templateFile} from "./key.ts";
 import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT} from "./store.ts";
 
 const key = (raw: string) => {
@@ -60,5 +60,33 @@ describe("the lane key", () => {
 
 	it("refuses an empty key rather than resolving it to the root itself", () => {
 		expect(reasonFor("")).toContain("empty");
+	});
+});
+
+describe("the issue a lane key drives", () => {
+	it("reads a bare numeric key as the issue itself", () => {
+		expect(keyIssue(key("8012"))).toBe(8012);
+		expect(rawKeyIssue("8012")).toBe(8012);
+	});
+
+	it("reads the leading segment of a quarantined key, not the whole directory name", () => {
+		expect(keyIssue(key("8012.frozen-deadlock-20260905T194736"))).toBe(8012);
+		expect(rawKeyIssue("7981.frozen-deadlock-1788645453")).toBe(7981);
+	});
+
+	it("resolves a chore key to no issue at all", () => {
+		expect(keyIssue(key("chore:park-sweep"))).toBeNull();
+		expect(rawKeyIssue("chore:park-sweep")).toBeNull();
+	});
+
+	it("resolves a key with no leading numeric segment to no issue", () => {
+		for (const raw of ["frozen-deadlock", "8012abc", ".8012", "8012."]) {
+			expect(rawKeyIssue(raw)).toBeNull();
+		}
+	});
+
+	it("resolves a malformed key to no issue rather than throwing", () => {
+		expect(rawKeyIssue("")).toBeNull();
+		expect(rawKeyIssue("chore:Park Sweep")).toBeNull();
 	});
 });

--- a/packages/fabrika-cli/src/lane/migrate-verb.ts
+++ b/packages/fabrika-cli/src/lane/migrate-verb.ts
@@ -34,7 +34,7 @@ import {isRecord, parseJson} from "../io/json.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {LANE_UNREADABLE, MIGRATION_UNSAFE, SHAPE_MISMATCH} from "./codes.ts";
 import type {ExpectationReader} from "./expectation.ts";
-import {CHORE_PREFIX} from "./key.ts";
+import {CHORE_PREFIX, rawKeyIssue} from "./key.ts";
 import {compileText} from "./machine.ts";
 import {type Drift, graftContext, judgeMigration, sameMachine} from "./migrate.ts";
 import {judgeShape, originOf} from "./shape.ts";
@@ -119,14 +119,8 @@ const keyOf = (root: string, name: string): string =>
 	// repository, so a relocated or derived root still keys its chores correctly.
 	root.endsWith(DEFAULT_CHORES_ROOT) ? `${CHORE_PREFIX}${name}` : name;
 
-/**
- * The issue this lane drives, or `null` when it drives none — a chore lane, or a directory whose name
- * is not a number and so names nothing on the board to judge against.
- */
-const issueOf = (root: string, name: string): number | null => {
-	if (root.endsWith(DEFAULT_CHORES_ROOT) || !/^\d+$/.test(name)) return null;
-	return Number(name);
-};
+/** The issue this lane drives, resolved through the one parse in `key.ts`; `null` when it drives none. */
+const issueOf = (root: string, name: string): number | null => rawKeyIssue(keyOf(root, name));
 
 const shapeOf = <R>(
 	issue: number,

--- a/packages/fabrika-cli/src/lane/reconcile-verb.ts
+++ b/packages/fabrika-cli/src/lane/reconcile-verb.ts
@@ -32,7 +32,7 @@ import {lockedRefusal, withLedgerLock} from "./append-lock.ts";
 import type {ClosureReader} from "./closure.ts";
 import {APPEND_UNKNOWN, LANE_UNREADABLE} from "./codes.ts";
 import {deriveStatus, foldLog, type LogEntry, standingCauses} from "./fold.ts";
-import {CHORE_PREFIX} from "./key.ts";
+import {CHORE_PREFIX, rawKeyIssue} from "./key.ts";
 import {compileText} from "./machine.ts";
 import {graftContext} from "./migrate.ts";
 import {correctionEntry, declaresClosureGuard, findMisroute} from "./reconcile.ts";
@@ -104,10 +104,7 @@ interface LaneRow {
 const keyOf = (root: string, name: string): string =>
 	root.endsWith(DEFAULT_CHORES_ROOT) ? `${CHORE_PREFIX}${name}` : name;
 
-const issueOf = (root: string, name: string): number | null => {
-	if (root.endsWith(DEFAULT_CHORES_ROOT) || !/^\d+$/.test(name)) return null;
-	return Number(name);
-};
+const issueOf = (root: string, name: string): number | null => rawKeyIssue(keyOf(root, name));
 
 /** The lane's folded state as one printable value, so a row shows the move it would make. */
 const foldedValue = (


### PR DESCRIPTION
Part of #8956.

Every lane verb that needed the issue a lane drives read it out of the whole directory name. The
quarantine convention appends `.frozen-deadlock-<stamp>` to that number, so `Number(name)` was `NaN`,
and `lane archive` then asked the board about `#NaN`, got Absent, and refused at exit 11 — with both
of its real gates holding. The directory's seat could not be freed by any verb.

The parse now lives once, in `lane/key.ts`:

- `keyIssue(key)` reads the key's leading numeric segment, dot-separated from any suffix. A chore key
  and a name with no leading number both resolve to `null`, unchanged.
- `rawKeyIssue(raw)` is the same answer from a raw key, for the sweeps that read directory names off
  a root.

Five call sites now route through it: `lane open`, `lane archive` and `lane settle` in
`lane/command.ts`, and the `issueOf` helpers in `reconcile-verb.ts` and `migrate-verb.ts` (those two
guarded with `/^\d+$/` and so answered `null` rather than `NaN` — correct, but a second copy of the
rule). `concurrency.ts`'s seat-ordering comparator resolved the same way, so it moved too; a lane
naming no issue now sorts after the numbered ones instead of falling through a `NaN` subtraction.

**Why the shared-helper route and not a new directory shape.** Renaming the quarantine convention to
something the old parsers accept would have to be done by hand on every existing directory — the
`mv` the `operate` skill forbids, which is the thing this issue is about — and it leaves the parse
rule copied in five places for the next convention to break. The helper fixes the class.

Proven end to end on a copy of a real quarantined lane under a scratch root: `lane archive
8005.frozen-deadlock-1788657104` printed `"issue": 8005` and moved the directory. `lane archive
chore:park-sweep` still refuses at exit 19.

## Deviations

- **Known defect left unfixed** — **Said:** acceptance criterion 5 asks that the four quarantined
  directories under `.fabrika/lanes` be archivable by the verb with no hand `mv`. **Did:** three of
  them (`7981.frozen-deadlock-1788645453`, `8005.frozen-deadlock-1788657104`,
  `8062.frozen-deadlock-1788659023`; the fourth was hand-moved before the issue was filed) are still
  not archivable — the `#NaN` refusal is gone, but they now stop at exit 50 instead. **Why:** their
  logs replay through the lane's own machine today, and `lane archive`'s other gate exists to refuse
  exactly that: a lane every sweep can judge is not one to move out of a sweep's scope. `lane status`
  reads all three `stateValue: tripped, status: done`, so they hold no seat against
  `laneConcurrencyCap` either — the wedge the criterion was written against is gone by a different
  route than this one. **Disposition:** opened `Part of` rather than `Fixes`, so the issue stays open
  for a human to judge whether that criterion is discharged or wants its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
