### PR TITLE
fix: lane settle's landing evidence still drops an epic tail that names the epic with Part of

### DIFF
--- a/packages/fabrika-cli/src/lane/settle.ts
+++ b/packages/fabrika-cli/src/lane/settle.ts
@@ -68,20 +68,33 @@ export type AssertedPull =
 	| {readonly _tag: "Unmerged"; readonly number: number; readonly state: string}
 	| {readonly _tag: "Absent"; readonly number: number};
 
-/** The merged pull requests whose body links this issue, through a closing keyword or `Part of`. */
+/**
+ * The merged pull requests whose body names this issue, through a closing keyword or `Part of`.
+ *
+ * The wide set ({@link PullFact.referencedIssues}), which is the same membership `landedFor` reads
+ * in `prove.ts`. {@link PullFact.linkedIssues} holds the winning kind's
+ * numbers alone, so on a body carrying both — an epic tail, closing one child per line and naming
+ * its epic with `Part of` — the epic is not in it, and reading it here made a finished epic's own
+ * tail invisible as evidence for the epic.
+ */
 export const mergedLinking = (
 	issue: number,
 	facts: ReadonlyArray<PullFact>,
 ): ReadonlyArray<PullFact> =>
-	facts.filter((fact) => fact.merged && fact.linkedIssues.includes(issue));
+	facts.filter((fact) => fact.merged && fact.referencedIssues.includes(issue));
 
 /** What one board read of the driving issue, plus its candidate pull requests, entitles. */
 export type Entitlement =
 	/** The board proved a not-planned or duplicate close; nothing shipped, so there is no evidence. */
 	| {readonly _tag: "Cancellable"; readonly event: string; readonly outcome: CancellationOutcome}
 	/**
-	 * The board proved a completed close AND at least one merged pull request linking the issue.
+	 * The board proved a completed close AND at least one merged pull request naming the issue.
 	 * `landed` is those pull requests' numbers — never empty, since an empty one is the `Unknown` arm.
+	 *
+	 * **Both reference kinds count.** A merge is evidence of a landing whether its body closes the
+	 * issue or only names it with `Part of` — the merge is what discharged the lane, and the keyword
+	 * only says who GitHub closes. Reading the closing kind alone loses the epic tail, which closes
+	 * its children and merely names its epic.
 	 */
 	| {
 			readonly _tag: "Landed";

--- a/packages/fabrika-cli/src/lane/settle.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/settle.unit.test.ts
@@ -58,6 +58,20 @@ describe("the settlement entitlement", () => {
 		expect(read).toMatchObject({_tag: "Landed", landed: [6874, 6900]});
 	});
 
+	it("lands an epic over its own tail, which closes the children and only names the epic", () => {
+		const tail = fact({
+			number: 8996,
+			linkedIssues: [7940, 7941],
+			linkKind: "fixes",
+			referencedIssues: [7940, 7941, ISSUE],
+		});
+
+		expect(entitlement(ISSUE, "closed", "completed", [tail])).toMatchObject({
+			_tag: "Landed",
+			landed: [8996],
+		});
+	});
+
 	it("refuses an open issue: its closure has said nothing yet", () => {
 		expect(entitlement(ISSUE, "open", null, null)).toEqual({_tag: "Live"});
 		expect(entitlement(ISSUE, "open", "reopened", null)).toEqual({_tag: "Live"});


### PR DESCRIPTION
`lane settle`'s `Landed` entitlement rests on `mergedLinking`, which filtered merged pull requests
on `PullFact.linkedIssues` — the winning reference kind's numbers alone. An epic tail's body closes
one child per line and names its epic with `Part of`, so the closing-beats-`Part of` precedence
pushed the epic out of that set: `mergedLinking(<epic>)` returned nothing, and a complete epic close
fell through to `Unknown`, telling the operator to name the merge by hand with `--landed-by` after a
whole finished run.

The filter now reads `referencedIssues`, which is what its own docblock always claimed and the same
wide membership `landedFor` reads in `prove.ts`. The `Landed` arm's docblock now states that both
reference kinds count as evidence, so the next reader does not re-derive it from the filter.

`traceClosure` is untouched and still reads `linkKind === "fixes" && linkedIssues.includes(issue)`.
It answers whether a merge *closes* this issue, and widening it would report an epic tail as closing
its own epic.

A new `settle.unit.test.ts` case pins the epic-tail shape: a merged `PullFact` whose `linkedIssues`
hold the children and whose `referencedIssues` additionally hold the epic is `Landed` evidence for
that epic. Every existing test in `packages/fabrika-cli/src/lane` still passes unchanged (1277).

Fixes #8997

## Deviations

None.
