### PR TITLE
chore: A lane's class:ui guard matched on a PASS carrying no class, routing a text-only PR into review:ui

### DIFF
--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -3,8 +3,10 @@ import {readGoldenFixture} from "../golden-fixture.ts";
 import {classifyPark, isPark} from "../recipe/parks.ts";
 import {MACHINERY_LAP_BUDGET, RETRY_BUDGET} from "../retry-budget.ts";
 import {WAIT_BUDGET} from "../wait-budget.ts";
+import {seedClasses} from "./class-seed.ts";
 import {
 	choreWorkflow,
+	coderTemplateText,
 	coderWorkflow,
 	stateNode,
 	twoPhaseWorkflow,
@@ -46,6 +48,8 @@ type Step =
 	| string
 	| {
 			readonly event: string;
+			/** Overrides the run's `classes`, so a step past the first can carry its own set. */
+			readonly classes?: ReadonlyArray<string>;
 			readonly waitGrant?: number;
 			readonly partial?: boolean;
 			readonly diagnosis?: boolean;
@@ -66,14 +70,16 @@ const drive = (
 	};
 	const reached = events.map((step, index) => {
 		const event = typeof step === "string" ? step : step.event;
-		// Only the first event carries the classes, so these tests also prove they stand afterwards.
+		// Only the first event carries the classes unless a step names its own, so these tests also
+		// prove they stand afterwards.
+		const stepClasses = typeof step === "string" ? undefined : step.classes;
 		const applied = applyEvent(
 			lane,
 			statesOf(),
 			task,
 			event,
 			"2026-08-17T00:00:00.000Z",
-			index === 0 ? classes : null,
+			stepClasses ?? (index === 0 ? classes : null),
 			typeof step === "string" ? null : (step.waitGrant ?? null),
 			typeof step === "string" ? false : (step.partial ?? false),
 			typeof step === "string" ? null : (step.diagnosis ?? null),
@@ -400,6 +406,34 @@ describe("the compiler — structural recognition", () => {
 			"review",
 			"ship",
 			"shipped",
+		]);
+	});
+
+	// The two below pin the routing an investigation read as a surprise: a `ui` class standing over
+	// the task takes the `review` arm into `review:ui` however the head's own diff partitions,
+	// because the class is sticky and an absent `--class` on the `PASS` changes nothing. Neither is a
+	// fix — they fix the leaf so a later narrowing of the sticky rule has to state itself here.
+	it("routes a seeded UI lane's classless PASS into review:ui, with no class on any event line", () => {
+		const seed = seedClasses(coderTemplateText(), ["ui"]);
+		if (seed._tag !== "Seeded") throw new Error(`expected a seeded document, got ${seed._tag}`);
+		const lane = compiled(JSON.parse(seed.text));
+
+		expect(leaves(lane, "issue", ["WIP", "DONE", "PASS"])).toEqual([
+			"build:ui",
+			"review",
+			"review:ui",
+		]);
+	});
+
+	it("lets the PASS's own class set replace the standing one, so a text-only head walks to ship", () => {
+		const seed = seedClasses(coderTemplateText(), ["ui"]);
+		if (seed._tag !== "Seeded") throw new Error(`expected a seeded document, got ${seed._tag}`);
+		const lane = compiled(JSON.parse(seed.text));
+
+		expect(leaves(lane, "issue", ["WIP", "DONE", {event: "PASS", classes: ["code"]}])).toEqual([
+			"build:ui",
+			"review",
+			"ship",
 		]);
 	});
 

--- a/reports/2026-09-10-lane-sticky-class-routes-text-only-pass.md
+++ b/reports/2026-09-10-lane-sticky-class-routes-text-only-pass.md
@@ -1,0 +1,104 @@
+# A lane's sticky `ui` class routes a text-only `PASS` into `review:ui`
+
+Finding for investigation [#8000](https://github.com/kamp-us/phoenix/issues/8000), which reported
+three lanes (7882, 7989, 7983) whose text-only pull request folded from `review` into `review:ui`
+instead of `ship`, on a `PASS` recorded with no `--class` flag.
+
+The guard is not defaulting true and reads nothing outside the lane. It reads
+[`TaskState.classes`](../packages/fabrika-cli/src/lane/machine.ts), which is sticky, and `ui` was
+already standing there.
+
+## The path, named
+
+Three sites, in the order the value travels:
+
+| Site | What it does |
+|---|---|
+| [`lane/report.ts`](../packages/fabrika-cli/src/lane/report.ts), `classesForEvent` | An empty `--class` answers `classes: null`, and [`report-verb.ts`](../packages/fabrika-cli/src/lane/report-verb.ts) omits the field from the appended line. |
+| [`lane/machine.ts`](../packages/fabrika-cli/src/lane/machine.ts), `withPayload` | `msg.classes === undefined` leaves the standing set alone. An omitted field means "no opinion", not "no class". |
+| [`lane/machine.ts`](../packages/fabrika-cli/src/lane/machine.ts), the `class:<name>` cell in `compileRegion` | `c.classes.includes("ui")` picks the `review:ui` arm off that standing set, never off the head. |
+
+Two things put `ui` into the standing set, and only one of them writes an event line:
+
+- **An event that carried `--class ui`.** `lane report` and `lane transition` are the only verbs
+  that write the field. This is the path
+  [the third comment on #8000](https://github.com/kamp-us/phoenix/issues/8000#issuecomment-5555545534)
+  records for lane 7983: its `ISSUE.WIP` carried `classes: ["ui"]`, because
+  [`operate`](../claude-plugins/fabrika/skills/operate/SKILL.md) tells the driver to relay the
+  ticket's class there.
+- **The lane document's own seed.** `lane open` reads the issue's `class:ui` label and writes
+  `context.<task>.classes` through
+  [`class-seed.ts`](../packages/fabrika-cli/src/lane/class-seed.ts), and the compiler seats that as
+  the task's initial `classes`. Every event line is then classless and the lane still routes `ui`.
+
+## Reproduced
+
+Driving the committed
+[`coder.workflow.json`](../packages/fabrika-cli/src/lane/templates/coder.workflow.json) through
+`applyEvent`, one row per starting condition:
+
+| Lane | `WIP` | `DONE` | `PASS` (no `--class`) |
+|---|---|---|---|
+| No class anywhere | `build` | `review` | **`ship`** |
+| `WIP` carried `--class ui` | `build:ui` | `review` | **`review:ui`** |
+| Document seeded `["ui"]`, no class on any line | `build:ui` | `review` | **`review:ui`** |
+| Document seeded `["ui"]`, `PASS` carried `--class code` | `build:ui` | `review` | **`ship`** |
+
+The last row is the part nothing in the pipeline uses: a `PASS` carrying the head's own derived
+class set *replaces* the standing one, and a text-only head then walks to `ship` with no machine
+change. Rows 3 and 4 are pinned in
+[`machine.unit.test.ts`](../packages/fabrika-cli/src/lane/machine.unit.test.ts); row 2 was already
+pinned there and row 1 is the report's own control.
+
+## What the filer could not see
+
+Row 1 is why #8000's body reports the two observations as unreproducible: a lane with no class in
+its document and none on any line routes to `ship`, and the filer read the *committed* template's
+`"classes": []` rather than lane 7882's own `workflow.json` context.
+
+The document seed did not exist on 2026-09-05, when 7882 and 7989 were observed — it landed
+2026-09-10 with [#9137](https://github.com/kamp-us/phoenix/pull/9137). So on that date the only
+producer was an event line, which is exactly what lane 7983's comment shows. Whether 7882 and 7989
+also carried one cannot be settled: both ledgers are machine-local and gone. What is settled is that
+the symptom needs no unexplained mechanism — two ordinary paths produce it, and both are reproduced
+above.
+
+Going forward the seed is the more common of the two, because `triage apply --class ui` on a ticket
+is all it takes.
+
+## ADR 0317's stickiness is the mechanism, and it is doing its job
+
+[ADR 0317](../.decisions/0317-ui-lane-carries-its-own-shells.md) puts the UI-ness on the lane state
+because a `build` state has no pull request, so there is no diff to classify from when the build
+shell is chosen. Stickiness is what carries that early read forward. Take it away and the first-pass
+`build:ui` route — the failure 0317 opens by naming — comes back.
+
+So the sticky rule is not wrong; it is under-specified at one boundary. Once the `PASS` exists there
+*is* a head, and `review scope` has derived the class set from it. At that point the ticket-time
+read and the head-time read are two different facts, and the machine has only one field.
+
+The two contracts have already picked opposite sides of it.
+[`operate`](../claude-plugins/fabrika/skills/operate/SKILL.md) says the class "stands from there —
+the `PASS` out of `review` routes to `review:ui` without you naming it again."
+[`review`](../claude-plugins/fabrika/skills/review/SKILL.md) says to pass `--class ui` "only when §1
+printed a `routed	review-ui` row, and never otherwise". A `class:ui` ticket with a text-only fix
+satisfies both and still takes the rendered arm — the reviewer omits the flag by instruction, not by
+mistake.
+
+Narrowing it is a decision, not a defect fix: it changes what an absent `--class` means, and every
+caller of `lane report` reads that. It is filed as
+[#9169](https://github.com/kamp-us/phoenix/issues/9169).
+
+## Its relationship to #6768
+
+Independent causes; one of them now feeds the other.
+
+[#6768](https://github.com/kamp-us/phoenix/issues/6768) was the mirror image — the seed field had no
+producer, so a rendered lane's *first* build ran in the plain builder. Its fix (#9137, 2026-09-10)
+added the producer. That does not explain #8000: lane 7983's class arrived on an event line, and
+lanes 7882 and 7989 predate the producer entirely.
+
+What the fix does is make #8000's symptom more reachable. Before it, only a driver passing
+`--class ui` could put the class on a lane; after it, a `class:ui` label does, on every lane, with
+nothing in the event log to show for it. The two findings constrain each other in exactly the way
+#8000 guessed: closing one widened the other.


### PR DESCRIPTION
The investigation's answer: the `class:ui` guard was never defaulting true and reads nothing outside
the lane. It reads `TaskState.classes`, which is sticky, and `ui` was already standing there.

Two things put it there, and only one writes an event line — an event that carried `--class ui`
(which is what lane 7983's own comment on the issue records), or the lane document's
`context.<task>.classes` seed, which `lane open` now writes off a `class:ui` label. That second one
is why the filer found no `classes` key anywhere in the log: it lives in `workflow.json`, and they
read the committed template rather than the lane's own copy.

`reports/2026-09-10-lane-sticky-class-routes-text-only-pass.md` carries the finding — the three code
sites the value travels through, a four-row reproduction against the committed `coder` template,
why lanes 7882 and 7989 cannot be settled from artifacts that no longer exist, and the relationship
to #6768 (independent causes, but #6768's fix made this symptom far more reachable).

Two regression tests in `packages/fabrika-cli/src/lane/machine.unit.test.ts` pin the leaf: a seeded
`ui` lane whose log carries no class at all reaches `review:ui`, and the same lane whose `PASS`
carries the head's own derived `--class code` reaches `ship`. That second row is the part nothing in
the pipeline uses today — the machine already lets the `PASS` replace the standing set.

The outcome is a design question rather than a code fix, so it is filed: #9169. `operate` tells the
driver the class "stands from there" past the `PASS`; `review` tells the reviewer to pass `--class`
only on a routed row. A `class:ui` ticket with a text-only fix satisfies both and still takes the
rendered arm. Narrowing that changes what an absent `--class` means for every caller of
`lane report`, which is a ruling, not a defect fix.

Reviewer: start with the report's reproduction table, then the two new tests — they are the table's
rows 3 and 4.

Fixes #8000

## Deviations

- **Declined guidance** — **Said:** acceptance criterion 5 asks for the design-question outcome to
  be filed already carrying its decision typing. **Did:** filed #9169 through the `report` skill,
  which leaves it in the needs-triage queue untyped. **Why:** that skill applies exactly one label
  and forbids a filer from typing or prioritizing what it files, so stamping it here would be
  indistinguishable from a triaged call. **Disposition:** stated here; triage types #9169.
- **Out-of-scope change** — **Said:** the issue asks for a regression test. **Did:** also extended
  the `drive` test helper's `Step` union with an optional `classes` field. **Why:** the helper only
  ever put classes on the first event, so the `PASS`-carries-its-own-set row was undrivable without
  it; the default path is unchanged. **Disposition:** stated here.
