### PR TITLE
fix: A green main plus an apps/-free diff produced a red tuval composer assertion in the merge queue

### DIFF
--- a/apps/tuval/src/shell/chat/composer-in-subagent-view.unit.test.tsx
+++ b/apps/tuval/src/shell/chat/composer-in-subagent-view.unit.test.tsx
@@ -13,7 +13,7 @@
  * behaviour can depend on which layer owns the parent.
  */
 
-import {act, fireEvent, render, within} from "@testing-library/react";
+import {act, fireEvent, render, waitFor, within} from "@testing-library/react";
 import {Effect} from "effect";
 import type {ReactElement} from "react";
 import {describe, expect, it} from "vitest";
@@ -64,12 +64,23 @@ const open = async () => {
 		expect(found, "no composer field").toBeTruthy();
 		return found as HTMLTextAreaElement;
 	};
+	const send = () => root.querySelector<HTMLButtonElement>("button[type='submit']");
+	// The transcript wait above says nothing about the composer. `AgentChatInput.Root` seeds
+	// `connection` as `"loading"` and leaves it only once its four bridge loaders resolve and React
+	// commits the answer, and `PrimaryActions` disables send for exactly that state — so an enabled
+	// send control is the one fact in this DOM that proves the bridge settled. Waiting on it rather
+	// than on a tick count is what keeps this helper right for a bridge slower than tuval's
+	// pre-resolved loaders (#9185).
+	await waitFor(() => {
+		expect(send(), "no send control").toBeTruthy();
+		expect(send()?.disabled, "composer bridge still loading").toBe(false);
+	});
 	return {
 		rendered,
 		root,
 		process,
 		composer,
-		send: () => root.querySelector<HTMLButtonElement>("button[type='submit']"),
+		send,
 		view: () => bound.view(),
 	};
 };


### PR DESCRIPTION
`open()` in `apps/tuval/src/shell/chat/composer-in-subagent-view.unit.test.tsx` returned as soon as
the transcript rendered, which says nothing about the composer. The composer mounts on
`AgentChatInput.Root`'s `connection: "loading"` seed and leaves it only when its four bridge loaders
resolve and React commits the answer, and `PrimaryActions` disables send for exactly that state — so
the first assertion, `expect(send()?.disabled).toBe(false)`, was reading a transient. That is the red
that ejected #9183 from the merge queue on a diff with nothing under `apps/`.

`open()` now ends on a `waitFor` for the send control being enabled: the one fact in this DOM that
proves the bridge settled, and an observable condition rather than a tick count. Every case enters
through that helper, so every `send()?.disabled` and `composer().disabled` read happens past the
settle. No product code changed — `Root.tsx` and `PrimaryActions.tsx` are untouched, no case is
skipped, and no retry count is raised.

Three proofs, each run locally in this tree:

- **The mechanism.** With `composerBridge`'s `loadPiState` delayed 400ms, the old helper reds exactly
  as the queue did — `AssertionError: expected false to be true` at the pre-navigation
  `send()?.disabled` line, plus the "re-enables on the way back" case. With the new helper and the
  same 400ms delay, all four cases pass. The delay was reverted before the commit; the diff is the
  test file alone.
- **No assertion weakened.** Setting `composerDisabled = false` in `ChatWindow.tsx` (a composer left
  enabled inside a subagent view) reds two cases: `composer().disabled` after picking the reviewer,
  and the Escape-back case. Reverted.
- **Twenty consecutive runs.** `pnpm --filter @kampus/tuval exec vitest run
  src/shell/chat/composer-in-subagent-view.unit.test.tsx` run 20 times back to back with 12 `yes`
  spinners saturating a 12-core machine: 20 passed, 0 failed, 1-minute load average 188.06 at the end
  of the loop.

Fixes #9185

## Deviations

None.
